### PR TITLE
bugfix #3

### DIFF
--- a/src/lib/MigrationBuilder.php
+++ b/src/lib/MigrationBuilder.php
@@ -95,8 +95,12 @@ class MigrationBuilder
         $this->migration = new MigrationModel($this->model, true);
         $this->uniqueColumns = $this->model->getUniqueColumnsList();
         $this->newColumns = $this->model->attributesToColumnSchema();
+        if (empty($this->newColumns)) {
+            return $this->migration;
+        }
         $builder = $this->recordBuilder;
         $tableName = $this->model->getTableAlias();
+
         $this->migration->addUpCode($builder->createTable($tableName, $this->newColumns, $this->uniqueColumns))
                         ->addDownCode($builder->dropTable($tableName));
         if ($this->isPostgres) {

--- a/src/lib/MigrationsGenerator.php
+++ b/src/lib/MigrationsGenerator.php
@@ -49,7 +49,7 @@ class MigrationsGenerator extends Component
                 $this->migrations[$model->tableAlias] = $migration;
             }
         }
-        return $this->sortMigrationsByDeps();
+        return !empty($this->migrations) ? $this->sortMigrationsByDeps() : [];
     }
 
     /**

--- a/tests/unit/MigrationsGeneratorTest.php
+++ b/tests/unit/MigrationsGeneratorTest.php
@@ -16,6 +16,15 @@ use function count;
 class MigrationsGeneratorTest extends TestCase
 {
 
+    public function testNoMigrations()
+    {
+        $this->prepareTempDir();
+        $this->mockApplication($this->mockDbSchemaAsEmpty());
+        $model = new DbModel(['name' => 'dummy', 'tableName' => 'dummy', 'attributes' => []]);
+        $generator = new MigrationsGenerator();
+        $migrations = $generator->generate([$model]);
+        self::assertEmpty($migrations);
+    }
     /**
      * @dataProvider simpleDbModelsProvider
      * @param array|DbModel[]        $dbModels


### PR DESCRIPTION
  - prevent 'create table migration' if it doesn't contain any column
  - fix error when changes for migrations are absent