### PR TITLE
Improves and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,17 +133,80 @@ Flag for unique column
 ```
 
 ### Many-to-Many relation definition
-- property name for many-to-many relation should be equal lower-cased, pluralized related schema name 
-- referenced schema should contains mirrored reference to current schema
-- migration for junction table can be generated automatically - table name should be [pluralized, lower-cased
+
+There are two ways for define many-to-many relations:
+
+#### Simple many-to-many without junction model
+
+   - property name for many-to-many relation should be equal lower-cased, pluralized related schema name
+     
+   - referenced schema should contains mirrored reference to current schema
+     
+   - migration for junction table can be generated automatically - table name should be [pluralized, lower-cased
  schema_name1]2[pluralized, lower-cased schema name2], in alphabetical order;
  For example, for schemas Post and Tag - table should be posts2tags, for schemas Post and Attachement - table should
   be attachments2posts
-- If you need custom junction table, (if it should contains additional attributes) - define schema model named as
-  [pluralized, pascal-cased schema_name1]2[pluralized, pascal-cased schema name2] in alphabetical order
-  For example, for schemas Post and Tag - junction schema name should be Posts2Tags, for schemas BlogPost and
-   BlogCategory - junction schema name should be BlogCategories2BlogPosts
- - see both examples here [tests/specs/many2many.yaml](tests/specs/many2many.yaml)         
+  
+```
+Post:
+  properties:
+  ...
+    tags:
+      type: array
+      items:
+        $ref: '#/components/schemas/Tag'
+
+Tag:
+  properties:
+  ...
+    posts:
+      type: array
+      items:
+        $ref: '#/components/schemas/Post'
+```
+  
+#### Many-to-many with junction model 
+
+This way allowed creating multiple many-to-many relations between to models 
+
+- define junction schema with all necessary attributes. There are only one important requirement - the junction
+ schema name
+ must be started with prefix 'junk_' (This prefix will be used internally only and
+ will be trimmed before table and model generation)
+ 
+```
+# Model TeamMembers with table team_members will be generated with columns team_id, user_id and role
+junk_TeamMembers:
+   team:
+      $ref: '#/components/schemas/Team'
+   user:
+      $ref: '#/components/schemas/User'
+   role:
+     type: string
+```
+- Both many-to-many related schemas must have properties with reference to "junk_*" schema. These properties will be
+ used as relation names 
+
+```
+Team:
+  properties:
+  ...
+     team_members:
+       type: array
+       items:
+         $ref: '#/components/schemas/junk_TeamMembers'
+
+User:
+  properties:
+  ...
+    memberships: #You absolutely free with naming for relationship attributes
+      type: array
+      items:
+        $ref: '#/components/schemas/junk_TeamMembers'
+```
+  
+ - see both examples here [tests/specs/many2many.yaml](tests/specs/many2many.yaml)
+ 
 
 ## Screenshots
 

--- a/README.md
+++ b/README.md
@@ -171,12 +171,12 @@ This way allowed creating multiple many-to-many relations between to models
 
 - define junction schema with all necessary attributes. There are only one important requirement - the junction
  schema name
- must be started with prefix 'junk_' (This prefix will be used internally only and
+ must be started with prefix 'junction_' (This prefix will be used internally only and
  will be trimmed before table and model generation)
  
 ```
 # Model TeamMembers with table team_members will be generated with columns team_id, user_id and role
-junk_TeamMembers:
+junction_TeamMembers:
    team:
       $ref: '#/components/schemas/Team'
    user:
@@ -184,7 +184,7 @@ junk_TeamMembers:
    role:
      type: string
 ```
-- Both many-to-many related schemas must have properties with reference to "junk_*" schema. These properties will be
+- Both many-to-many related schemas must have properties with reference to "junction_*" schema. These properties will be
  used as relation names 
 
 ```
@@ -194,7 +194,7 @@ Team:
      team_members:
        type: array
        items:
-         $ref: '#/components/schemas/junk_TeamMembers'
+         $ref: '#/components/schemas/junction_TeamMembers'
 
 User:
   properties:
@@ -202,7 +202,7 @@ User:
     memberships: #You absolutely free with naming for relationship attributes
       type: array
       items:
-        $ref: '#/components/schemas/junk_TeamMembers'
+        $ref: '#/components/schemas/junction_TeamMembers'
 ```
   
  - see both examples here [tests/specs/many2many.yaml](tests/specs/many2many.yaml)

--- a/src/generator/default/dbmodel.php
+++ b/src/generator/default/dbmodel.php
@@ -4,6 +4,7 @@
  * @var string $namespace
  * @var string $relationNamespace
  **/
+use yii\helpers\Inflector;
 use yii\helpers\VarDumper;
 
 ?>
@@ -23,9 +24,9 @@ namespace <?= $namespace ?>;
  *
 <?php foreach ($model->relations as $relationName => $relation): ?>
 <?php if ($relation->isHasOne()):?>
- * @property \<?= trim($relationNamespace, '\\') ?>\<?= $relation->getClassName() ?> $<?= $relationName ?>
+ * @property \<?= trim($relationNamespace, '\\') ?>\<?= $relation->getClassName() ?> $<?= Inflector::variablize($relation->getName()) ?>
 <?php else:?>
- * @property array|\<?= trim($relationNamespace, '\\') ?>\<?= $relation->getClassName() ?>[] $<?= $relationName ?>
+ * @property array|\<?= trim($relationNamespace, '\\') ?>\<?= $relation->getClassName() ?>[] $<?= Inflector::variablize($relation->getName()) ?>
 <?php endif?>
 
 <?php endforeach; ?>
@@ -62,7 +63,7 @@ abstract class <?= $model->getClassName() ?> extends \yii\db\ActiveRecord
 <?php if (!$relation->hasViaModel):?>
                     ->viaTable(<?=VarDumper::export($relation->viaTableName)?>, <?=$relation->linkToString($relation->viaLink)?>);
 <?php else:?>
-                    ->via('<?=lcfirst($relation->getViaModelName())?>');
+                    ->via('<?=lcfirst($relation->getViaRelationName())?>');
 <?php endif;?>
     }
 <?php endforeach; ?>

--- a/src/generator/default/dbmodel.php
+++ b/src/generator/default/dbmodel.php
@@ -31,7 +31,7 @@ namespace <?= $namespace ?>;
 
 <?php endforeach; ?>
 <?php foreach ($model->many2many as $relation): ?>
- * @property array|\<?= trim($relationNamespace, '\\') ?>\<?= $relation->relatedClassName ?>[] $<?= $relation->name ?>
+ * @property array|\<?= trim($relationNamespace, '\\') ?>\<?= $relation->relatedClassName ?>[] $<?= Inflector::variablize($relation->name) ?>
 
 <?php endforeach; ?>
  */

--- a/src/generator/default/faker.php
+++ b/src/generator/default/faker.php
@@ -49,7 +49,7 @@ class <?= $model->getClassName() ?>Faker
     public static function makeOne(array $attributes, bool $save = false)
     {
         $model = (new static())->generateModel();
-        $model->setAttributes($attributes);
+        $model->setAttributes($attributes, false);
         if ($save === true) {
             $model->save();
         }

--- a/src/lib/AttributeResolver.php
+++ b/src/lib/AttributeResolver.php
@@ -162,12 +162,15 @@ class AttributeResolver
                 'pkAttribute' => $this->attributes[$this->primaryKey],
                 'hasViaModel' => true,
                 'viaModelName' => $viaModel,
-                'viaRelationName' => Inflector::id2camel($junkRef, '_')
+                'viaRelationName' => Inflector::id2camel($junkRef, '_'),
+                'fkProperty' => $junkAttribute['pairProperty'],
+                'relatedFkProperty' => $junkAttribute['property'],
             ]);
             $this->many2many[Inflector::pluralize($junkProperty)] = $relation;
+
             $this->relations[Inflector::pluralize($junkRef)] =
                 (new AttributeRelation($junkRef, $junkAttribute['junctionTable'], $viaModel))
-                    ->asHasMany([Inflector::camel2id($this->schemaName, '_') . '_id' => $this->primaryKey]);
+                    ->asHasMany([$junkAttribute['pairProperty'].'_id' => $this->primaryKey]);
             return;
         }
 

--- a/src/lib/AttributeResolver.php
+++ b/src/lib/AttributeResolver.php
@@ -14,6 +14,7 @@ use cebe\openapi\SpecObjectInterface;
 use cebe\yii2openapi\lib\items\Attribute;
 use cebe\yii2openapi\lib\items\AttributeRelation;
 use cebe\yii2openapi\lib\items\DbModel;
+use cebe\yii2openapi\lib\items\JunctionSchemas;
 use cebe\yii2openapi\lib\items\ManyToManyRelation;
 use Throwable;
 use Yii;
@@ -29,8 +30,8 @@ use function substr;
 
 class AttributeResolver
 {
-    private const REFERENCE_PATH = '/components/schemas/';
-    private const REFERENCE_PATH_LEN = 20;
+    public const REFERENCE_PATH = '/components/schemas/';
+    public const REFERENCE_PATH_LEN = 20;
 
     /**
      * @var Attribute[]|array
@@ -64,12 +65,26 @@ class AttributeResolver
      */
     private $tableName;
 
-    public function __construct(string $schemaName, Schema $componentSchema)
+    /**
+     * @var \cebe\yii2openapi\lib\items\JunctionSchemas
+     */
+    private $junctions;
+
+    /**@var bool */
+    private $isJunctionSchema;
+
+    /**@var bool */
+    private $hasMany2Many;
+
+    public function __construct(string $schemaName, Schema $componentSchema, JunctionSchemas $junctions)
     {
         $this->schemaName = $schemaName;
         $this->componentSchema = $componentSchema;
         $this->primaryKey = $componentSchema->{CustomSpecAttr::PRIMARY_KEY} ?? 'id';
         $this->tableName = $componentSchema->{CustomSpecAttr::TABLE} ?? self::tableNameBySchema($this->schemaName);
+        $this->junctions = $junctions;
+        $this->isJunctionSchema = $junctions->isJunctionSchema($schemaName);
+        $this->hasMany2Many = $junctions->hasMany2Many($schemaName);
     }
 
     /**
@@ -80,7 +95,13 @@ class AttributeResolver
         $requiredProps = $this->componentSchema->required ?? [];
         foreach ($this->componentSchema->properties as $propertyName => $property) {
             $isRequired = in_array($propertyName, $requiredProps);
-            $this->resolveProperty($propertyName, $property, $isRequired);
+            if ($this->isJunctionSchema) {
+                $this->resolveJunctionTableProperty($propertyName, $property, $isRequired);
+            } elseif ($this->hasMany2Many) {
+                $this->resolveHasMany2ManyTableProperty($propertyName, $property, $isRequired);
+            } else {
+                $this->resolveProperty($propertyName, $property, $isRequired);
+            }
         }
         return new DbModel([
             'pkName' => $this->primaryKey,
@@ -90,12 +111,67 @@ class AttributeResolver
             'attributes' => $this->attributes,
             'relations' => $this->relations,
             'many2many' => $this->many2many,
+            //For valid primary keys for junction tables
+            'junctionCols' => $this->isJunctionSchema ? $this->junctions->junctionCols($this->schemaName) : []
         ]);
     }
 
     public static function tableNameBySchema(string $schemaName):string
     {
         return Inflector::camel2id(StringHelper::basename(Inflector::pluralize($schemaName)), '_');
+    }
+
+    protected function resolveJunctionTableProperty($propertyName, SpecObjectInterface $property, bool $isRequired)
+    {
+        if ($this->junctions->isJunctionProperty($this->schemaName, $propertyName)) {
+            $junkAttribute = $this->junctions->byJunctionSchema($this->schemaName)[$propertyName];
+            $attribute = new Attribute($propertyName);
+            $attribute->setRequired($isRequired)
+                      ->setDescription($property->description ?? '')
+                      ->setReadOnly($property->readOnly ?? false)
+                      ->setIsPrimary($propertyName === $this->primaryKey)
+                      ->asReference($junkAttribute['relatedClassName'])
+                      ->setPhpType($junkAttribute['phpType'])
+                      ->setDbType($junkAttribute['dbType']);
+            $relation = (new AttributeRelation($propertyName, $junkAttribute['relatedTableName'], $junkAttribute['relatedClassName']))
+                ->asHasOne([$junkAttribute['foreignPk'] => $attribute->columnName]);
+            $this->relations[$propertyName] = $relation;
+            $this->attributes[$propertyName] = $attribute->setFakerStub($this->guessFakerStub($attribute, $property));
+        } else {
+            $this->resolveProperty($propertyName, $property, $isRequired);
+        }
+    }
+
+    protected function resolveHasMany2ManyTableProperty($propertyName, SpecObjectInterface $property, bool $isRequired)
+    {
+        if ($this->junctions->isManyToManyProperty($this->schemaName, $propertyName)) {
+            return;
+        }
+        if ($this->junctions->isJunctionRef($this->schemaName, $propertyName)) {
+            $junkAttribute = $this->junctions->indexByJunctionRef()[$propertyName][$this->schemaName];
+            $junkRef = $propertyName;
+            $junkProperty = $junkAttribute['property'];
+            $viaModel = $this->junctions->trimPrefix($junkAttribute['junctionSchema']);
+
+            $relation = new ManyToManyRelation([
+                'name' => Inflector::pluralize($junkProperty),
+                'schemaName' => $this->schemaName,
+                'relatedSchemaName' => $junkAttribute['relatedClassName'],
+                'tableName' => $this->tableName,
+                'relatedTableName' => $junkAttribute['relatedTableName'],
+                'pkAttribute' => $this->attributes[$this->primaryKey],
+                'hasViaModel' => true,
+                'viaModelName' => $viaModel,
+                'viaRelationName' => Inflector::id2camel($junkRef, '_')
+            ]);
+            $this->many2many[Inflector::pluralize($junkProperty)] = $relation;
+            $this->relations[Inflector::pluralize($junkRef)] =
+                (new AttributeRelation($junkRef, $junkAttribute['junctionTable'], $viaModel))
+                    ->asHasMany([Inflector::camel2id($this->schemaName, '_') . '_id' => $this->primaryKey]);
+            return;
+        }
+
+        $this->resolveProperty($propertyName, $property, $isRequired);
     }
 
     protected function resolveProperty($propertyName, SpecObjectInterface $property, bool $isRequired)

--- a/src/lib/FractalGenerator.php
+++ b/src/lib/FractalGenerator.php
@@ -80,7 +80,7 @@ class FractalGenerator extends UrlGenerator
         return new FractalAction([
             'singularResourceKey'=> $this->singularResourceKeys,
             'type' => $routeData->type,
-            'id' => $routeData->isNonCrudAction()?"{$actionType}-{$routeData->action}":"$actionType{$routeData->action}",
+            'id' => $routeData->isNonCrudAction()?trim("{$actionType}-{$routeData->action}", '-'):"$actionType{$routeData->action}",
             'controllerId' => $controllerId,
             'urlPath' => $routeData->path,
             'requestMethod' => strtoupper($method),

--- a/src/lib/SchemaResponseResolver.php
+++ b/src/lib/SchemaResponseResolver.php
@@ -12,6 +12,7 @@ use cebe\openapi\spec\Operation;
 use cebe\openapi\spec\Reference;
 use cebe\openapi\spec\Schema;
 use cebe\openapi\SpecObjectInterface;
+use cebe\yii2openapi\lib\items\JunctionSchemas;
 use function array_keys;
 use function explode;
 
@@ -47,7 +48,8 @@ class SchemaResponseResolver
 //            $schemaOrReference->resolve();
 //        }
         $ref = $schemaOrReference->getJsonReference()->getJsonPointer()->getPointer();
-        return strpos($ref, '/components/schemas/') === 0 ? substr($ref, 20) : null;
+        $name = strpos($ref, '/components/schemas/') === 0 ? substr($ref, 20) : null;
+        return \str_replace(JunctionSchemas::PREFIX, '', $name);
     }
 
     public static function guessResponseRelations(Operation $operation):array

--- a/src/lib/SchemaToDatabase.php
+++ b/src/lib/SchemaToDatabase.php
@@ -195,9 +195,11 @@ class SchemaToDatabase extends Component
             $junkRef0 = $propertyMap[0]['refProperty'];
             $junkRef1 = $propertyMap[1]['refProperty'];
             $propertyMap[0]['class'] = $propertyMap[1]['targetClass'];
+            $propertyMap[0]['pairProperty'] = $propertyMap[1]['property'];
             $propertyMap[0]['refProperty'] = $junkRef1;
             $propertyMap[1]['class'] = $propertyMap[0]['targetClass'];
             $propertyMap[1]['refProperty'] = $junkRef0;
+            $propertyMap[1]['pairProperty'] = $propertyMap[0]['property'];
             $junctions[] = $propertyMap[0];
             $junctions[] = $propertyMap[1];
             unset($junkRef, $junkRef1, $junkRef0, $propertyMap);

--- a/src/lib/SchemaToDatabase.php
+++ b/src/lib/SchemaToDatabase.php
@@ -116,9 +116,15 @@ class SchemaToDatabase extends Component
     {
         $junctions = [];
         foreach ($openApi->components->schemas as $schemaName => $schema) {
-            if (!StringHelper::startsWith($schemaName, 'junk_') || $schema instanceof Reference) {
+            if (!StringHelper::startsWith($schemaName, JunctionSchemas::PREFIX)) {
                 continue;
             }
+
+            if ($schema instanceof Reference) {
+                $schema->getContext()->mode = ReferenceContext::RESOLVE_MODE_INLINE;
+                $schema = $schema->resolve();
+            }
+
             if (!$this->canGenerateModel($schemaName, $schema)) {
                 continue;
             }
@@ -141,6 +147,9 @@ class SchemaToDatabase extends Component
                 $relatedClassName = Inflector::id2camel($relatedClassName, '_');
 
                 foreach ($relatedSchema->properties as $propName => $prop) {
+                    if ($prop instanceof Reference) {
+                        continue;
+                    }
                     if (!($prop->type === 'array' && isset($prop->items) && $prop->items instanceof Reference)) {
                         continue;
                     }

--- a/src/lib/SchemaToDatabase.php
+++ b/src/lib/SchemaToDatabase.php
@@ -11,10 +11,14 @@ use cebe\openapi\ReferenceContext;
 use cebe\openapi\spec\OpenApi;
 use cebe\openapi\spec\Reference;
 use cebe\openapi\spec\Schema;
-use cebe\yii2openapi\lib\items\DbModel;
+use cebe\yii2openapi\lib\items\JunctionSchemas;
 use Yii;
 use yii\base\Component;
+use yii\base\Exception;
+use yii\helpers\Inflector;
 use yii\helpers\StringHelper;
+use function count;
+use function str_replace;
 
 /**
  * Convert OpenAPI description into a database schema.
@@ -24,10 +28,8 @@ use yii\helpers\StringHelper;
  * 2. Explicitly define schemas which represent a database table by adding the
  *    `x-table` property to the schema.
  * The [[]]
- *
  * OpenApi Schema definition rules for database conversion:
  * https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#schema-object
- *
  * components:
  *     schemas:
  *        ModelName: #(table name becomes model_names)
@@ -51,7 +53,6 @@ use yii\helpers\StringHelper;
  *                  x-db-unique: true #(mark unique attribute for database and validation constraining)
  *                  x-faker: #(custom faker generator, for ex '$faker->gender')
  *                  description: #(optional, used for comment)
- *
  */
 class SchemaToDatabase extends Component
 {
@@ -60,6 +61,7 @@ class SchemaToDatabase extends Component
      * @var array List of model names to exclude.
      */
     public $excludeModels = [];
+
     public $skipUnderscoredSchemas = true;
 
     /**
@@ -78,6 +80,7 @@ class SchemaToDatabase extends Component
     public function generateModels(OpenApi $openApi):array
     {
         $models = [];
+        $junctions = $this->findJunctionSchemas($openApi);
         foreach ($openApi->components->schemas as $schemaName => $schema) {
             if ($schema instanceof Reference) {
                 $schema->getContext()->mode = ReferenceContext::RESOLVE_MODE_INLINE;
@@ -87,8 +90,11 @@ class SchemaToDatabase extends Component
             if (!$this->canGenerateModel($schemaName, $schema)) {
                 continue;
             }
-            /**@var \cebe\yii2openapi\lib\AttributeResolver $resolver*/
-            $resolver = Yii::createObject($this->attributeResolverClass, [$schemaName, $schema]);
+            if ($junctions->isJunctionSchema($schemaName)) {
+                $schemaName = $junctions->trimPrefix($schemaName);
+            }
+            /**@var \cebe\yii2openapi\lib\AttributeResolver $resolver */
+            $resolver = Yii::createObject($this->attributeResolverClass, [$schemaName, $schema, $junctions]);
             $models[$schemaName] = $resolver->resolve();
         }
         foreach ($models as $schemaName => $model) {
@@ -104,6 +110,90 @@ class SchemaToDatabase extends Component
         // TODO generate inverse relations
 
         return $models;
+    }
+
+    public function findJunctionSchemas(OpenApi $openApi):JunctionSchemas
+    {
+        $junctions = [];
+        foreach ($openApi->components->schemas as $schemaName => $schema) {
+            if (!StringHelper::startsWith($schemaName, 'junk_') || $schema instanceof Reference) {
+                continue;
+            }
+            if (!$this->canGenerateModel($schemaName, $schema)) {
+                continue;
+            }
+
+            $propertyMap = [];
+            $tableName = $schema->{CustomSpecAttr::TABLE} ??
+                AttributeResolver::tableNameBySchema(str_replace(JunctionSchemas::PREFIX, '', $schemaName));
+            foreach ($schema->properties as $propertyName => $property) {
+                if (!$property instanceof Reference) {
+                    continue;
+                }
+                $junkRef = null;
+                $refPointer = $property->getJsonReference()->getJsonPointer()->getPointer();
+                $property->getContext()->mode = ReferenceContext::RESOLVE_MODE_ALL;
+                $relatedSchema = $property->resolve();
+                if (!strpos($refPointer, AttributeResolver::REFERENCE_PATH) === 0) {
+                    continue;
+                }
+                $relatedClassName = substr($refPointer, AttributeResolver::REFERENCE_PATH_LEN);
+                $relatedClassName = Inflector::id2camel($relatedClassName, '_');
+
+                foreach ($relatedSchema->properties as $propName => $prop) {
+                    if (!($prop->type === 'array' && isset($prop->items) && $prop->items instanceof Reference)) {
+                        continue;
+                    }
+                    $ref = $prop->items->getJsonReference()->getJsonPointer()->getPointer();
+                    if ($schemaName === substr($ref, AttributeResolver::REFERENCE_PATH_LEN)) {
+                        $junkRef = $propName;
+                        break;
+                    }
+                }
+                if ($junkRef) {
+                    $relatedTableName =
+                        $relatedSchema->{CustomSpecAttr::TABLE} ??
+                        AttributeResolver::tableNameBySchema($relatedClassName);
+                    $foreignPk = $relatedSchema->{CustomSpecAttr::PRIMARY_KEY} ?? 'id';
+                    $foreignPkProperty = $relatedSchema->properties[$foreignPk];
+                    if ($foreignPkProperty === null) {
+                        //Non-db
+                        break;
+                    }
+                    $phpType = SchemaTypeResolver::schemaToPhpType($foreignPkProperty);
+                    $dbType = SchemaTypeResolver::referenceToDbType($foreignPkProperty);
+                    $propertyMap[] = [
+                        'property' => $propertyName,
+                        'targetClass' => $relatedClassName,
+                        'refProperty' => $junkRef,
+                        'junctionSchema' => $schemaName,
+                        'junctionTable' => $tableName,
+                        'relatedClassName' => $relatedClassName,
+                        'relatedTableName' => $relatedTableName,
+                        'foreignPk' => $foreignPk,
+                        'phpType' => $phpType,
+                        'dbType' => $dbType,
+                    ];
+                }
+
+                if (count($propertyMap) === 2) {
+                    break;
+                }
+            }
+            if (count($propertyMap) !== 2) {
+                throw new Exception('Junction table must contains 2 attributes referenced on other schemas');
+            }
+            $junkRef0 = $propertyMap[0]['refProperty'];
+            $junkRef1 = $propertyMap[1]['refProperty'];
+            $propertyMap[0]['class'] = $propertyMap[1]['targetClass'];
+            $propertyMap[0]['refProperty'] = $junkRef1;
+            $propertyMap[1]['class'] = $propertyMap[0]['targetClass'];
+            $propertyMap[1]['refProperty'] = $junkRef0;
+            $junctions[] = $propertyMap[0];
+            $junctions[] = $propertyMap[1];
+            unset($junkRef, $junkRef1, $junkRef0, $propertyMap);
+        }
+        return new JunctionSchemas($junctions);
     }
 
     private function canGenerateModel(string $schemaName, Schema $schema):bool

--- a/src/lib/UrlGenerator.php
+++ b/src/lib/UrlGenerator.php
@@ -112,7 +112,7 @@ class UrlGenerator
         }
 
         return new RestAction([
-            'id' => "$actionType{$routeData->action}",
+            'id' => trim("$actionType{$routeData->action}", '-'),
             'controllerId' => $controllerId,
             'urlPath' => $routeData->path,
             'requestMethod' => strtoupper($method),

--- a/src/lib/items/DbModel.php
+++ b/src/lib/items/DbModel.php
@@ -60,6 +60,8 @@ class DbModel extends BaseObject
      */
     public $many2many = [];
 
+    public $junctionCols = [];
+
     public function getTableAlias():string
     {
         return '{{%' . $this->tableName . '}}';

--- a/src/lib/items/JunctionSchemas.php
+++ b/src/lib/items/JunctionSchemas.php
@@ -16,7 +16,7 @@ use function str_replace;
 
 class JunctionSchemas
 {
-    public const PREFIX = 'junk_';
+    public const PREFIX = 'junction_';
 
     /**@var array */
     private $data = [];

--- a/src/lib/items/JunctionSchemas.php
+++ b/src/lib/items/JunctionSchemas.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * @copyright Copyright (c) 2018 Carsten Brandt <mail@cebe.cc> and contributors
+ * @license https://github.com/cebe/yii2-openapi/blob/master/LICENSE
+ */
+
+namespace cebe\yii2openapi\lib\items;
+
+use yii\helpers\ArrayHelper;
+use yii\helpers\Inflector;
+use yii\helpers\StringHelper;
+use function array_key_exists;
+use function array_map;
+use function str_replace;
+
+class JunctionSchemas
+{
+    public const PREFIX = 'junk_';
+
+    /**@var array */
+    private $data = [];
+
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
+
+    public function byClassSchema(string $name):array
+    {
+        return $this->indexByClassSchema()[$name] ?? [];
+    }
+
+    public function byJunctionSchema(string $schemaName):array
+    {
+        return $this->indexByJunctionSchema()[$this->addPrefix($schemaName)] ?? [];
+    }
+
+    public function isJunctionSchema(string $schemaName):bool
+    {
+        return array_key_exists($this->addPrefix($schemaName), $this->indexByJunctionSchema());
+    }
+
+    public function hasMany2Many(string $schemaName):bool
+    {
+        return array_key_exists($schemaName, $this->indexByClassSchema());
+    }
+
+    public function isManyToManyProperty(string $schemaName, string $propertyName):bool
+    {
+        $otherCase = Inflector::singularize($propertyName);
+        if ($otherCase === $propertyName) {
+            $otherCase = Inflector::pluralize($propertyName);
+        }
+        return array_key_exists($propertyName, $this->byClassSchema($schemaName))
+               || array_key_exists($otherCase, $this->byClassSchema($schemaName));
+    }
+
+    public function isJunctionRef(string $schemaName, string $propertyName):bool
+    {
+        return array_key_exists(
+            $propertyName,
+            ArrayHelper::index($this->data, 'refProperty', 'class')[$schemaName] ?? []
+        );
+    }
+
+    public function isJunctionProperty(string $schemaName, string $propertyName):bool
+    {
+        return array_key_exists($propertyName, $this->byJunctionSchema($schemaName));
+    }
+
+    public function indexByClassSchema():array
+    {
+        return ArrayHelper::index($this->data, 'property', 'class');
+    }
+
+    public function indexByJunctionSchema():array
+    {
+        return ArrayHelper::index($this->data, 'property', 'junctionSchema');
+    }
+
+    public function indexByJunctionRef():array
+    {
+        return ArrayHelper::index($this->data, 'class', 'refProperty');
+    }
+
+    public function addPrefix(string $schemaName):string
+    {
+        return StringHelper::startsWith($schemaName, self::PREFIX) ? $schemaName : self::PREFIX . $schemaName;
+    }
+
+    public function trimPrefix(string $schemaName):string
+    {
+        return str_replace(self::PREFIX, '', $schemaName);
+    }
+
+    public function junctionCols(string $schemaName):array
+    {
+        return array_values(
+            array_map(function (array $data) {
+                return $data['property'] . '_id';
+            }, $this->byJunctionSchema($schemaName))
+        );
+    }
+}

--- a/src/lib/items/ManyToManyRelation.php
+++ b/src/lib/items/ManyToManyRelation.php
@@ -21,7 +21,6 @@ use function strtolower;
  * @property-read string[]               $link
  * @property-read string                 $relatedFk
  * @property-read string                 $selfFk
- * @property-read string                 $viaModelName
  * @property-read string                 $viaTableAlias
  * @property-read string                 $camelName
  * @property-read string                 $className
@@ -55,6 +54,12 @@ class ManyToManyRelation extends BaseObject
     /**@var \cebe\yii2openapi\lib\items\Attribute */
     public $relatedPkAttribute;
 
+    /**@var string**/
+    public $viaModelName;
+
+    /**@var string**/
+    public $viaRelationName;
+
     public function getCamelName():string
     {
         return Inflector::camelize($this->name);
@@ -78,12 +83,24 @@ class ManyToManyRelation extends BaseObject
      */
     public function getViaModelName():string
     {
-        $names = [
-            Inflector::pluralize(Inflector::id2camel($this->className, '_')),
-            Inflector::pluralize(Inflector::id2camel($this->relatedClassName, '_')),
-        ];
-        sort($names);
-        return implode('2', $names);
+        if (!$this->viaModelName) {
+            $names = [
+                Inflector::pluralize(Inflector::id2camel($this->className, '_')),
+                Inflector::pluralize(Inflector::id2camel($this->relatedClassName, '_')),
+            ];
+            sort($names);
+            return implode('2', $names);
+        }
+        return $this->viaModelName;
+    }
+
+    /**
+     * For cases when relation name and viaModel are different
+     * @return string
+     */
+    public function getViaRelationName(): string
+    {
+        return $this->viaRelationName? $this->viaRelationName : $this->getViaModelName();
     }
 
     /**

--- a/src/lib/items/ManyToManyRelation.php
+++ b/src/lib/items/ManyToManyRelation.php
@@ -60,6 +60,11 @@ class ManyToManyRelation extends BaseObject
     /**@var string**/
     public $viaRelationName;
 
+    /**@var string**/
+    public $fkProperty;
+    /**@var string**/
+    public $relatedFkProperty;
+
     public function getCamelName():string
     {
         return Inflector::camelize($this->name);
@@ -126,12 +131,14 @@ class ManyToManyRelation extends BaseObject
 
     public function getSelfFk():string
     {
-        return strtolower(Inflector::camel2id($this->schemaName, '_')) . '_id';
+        $fk = $this->fkProperty ?? $this->schemaName;
+        return strtolower(Inflector::camel2id($fk, '_')) . '_id';
     }
 
     public function getRelatedFk():string
     {
-        return strtolower(Inflector::camel2id($this->relatedSchemaName, '_')) . '_id';
+        $fk = $this->relatedFkProperty ?? $this->relatedSchemaName;
+        return strtolower(Inflector::camel2id($fk, '_')) . '_id';
     }
 
     public function getLink():array

--- a/src/lib/items/RouteData.php
+++ b/src/lib/items/RouteData.php
@@ -41,7 +41,7 @@ final class RouteData extends BaseObject
      * @example /auth/reset/password
      * @example /auth/verify/{email}
      */
-    private const PATTERN_ACTION = '~^/(?<controller>[\w-]+)/(?<action>[\w-]+)/?(?<method>[\w-]+)?/?(?:[{}/\w-]+)?$~';
+    private const PATTERN_ACTION = '~^/(?<controller>[\w-]+)/(?<action>[\w-]+)/?({(?<param>[\w-]+)}/)?(?<method>[\w-]+)?/?(?:[{}/\w-]+)?$~';
     /** @example /posts */
     private const PATTERN_LIST = '~^/(?<controller>[\w-]+)$~';
     /**
@@ -304,6 +304,9 @@ final class RouteData extends BaseObject
 
     public function resolveGetActionType():string
     {
+        if ($this->type === self::TYPE_DEFAULT) {
+            return '';
+        }
         if ($this->type === self::TYPE_PROFILE || $this->isNonCrudAction()) {
             return 'view';
         }

--- a/src/lib/items/Transformer.php
+++ b/src/lib/items/Transformer.php
@@ -9,6 +9,7 @@ namespace cebe\yii2openapi\lib\items;
 
 use yii\base\BaseObject;
 use yii\helpers\Inflector;
+use function array_map;
 
 /**
  * @property-read string                                                 $name
@@ -93,7 +94,15 @@ class Transformer extends BaseObject
 
     public function getAvailableRelations(): array
     {
-        return array_merge(array_keys($this->dbModel->relations), array_keys($this->dbModel->many2many));
+        $relations = array_map(function (AttributeRelation $relation) {
+            return Inflector::variablize($relation->getName());
+        }, $this->dbModel->relations);
+
+        $relationsMany = array_map(function (ManyToManyRelation $relation) {
+            return Inflector::variablize($relation->name);
+        }, $this->dbModel->many2many);
+
+        return array_merge($relations, $relationsMany);
     }
 
     public function makeResourceKey(string $value): string

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,34 +1,48 @@
 <?php
+
 namespace tests;
 
+use PHPUnit\Runner\Version;
 use Yii;
 use yii\db\Connection;
 use yii\db\Schema;
 use yii\helpers\ArrayHelper;
 use yii\helpers\FileHelper;
 use yii\web\Application;
+use function array_diff;
 
 class TestCase extends \PHPUnit\Framework\TestCase
 {
-     protected function prepareTempDir()
-     {
-         FileHelper::removeDirectory(__DIR__ . '/tmp/app');
-         FileHelper::createDirectory(__DIR__ . '/tmp/app');
-         Yii::setAlias('@app', __DIR__ . '/tmp/app');
-     }
+    public static function assertEqualsCanonicalizing($expected, $actual, string $message = '')
+    {
+        if ((int)Version::id()[0] >= 8) {
+            parent::assertEqualsCanonicalizing($expected, $actual, $message);
+        } else {
+            self::assertTrue(empty(array_diff($expected, $actual)) && empty(array_diff($actual, $expected)));
+        }
 
-     protected function mockApplication(?Connection $dbMock, array $extendConfig = []):Application
-     {
-         $config = ArrayHelper::merge([
-             'id' => 'yii2-openapi-test',
-             'basePath' => __DIR__ . '/tmp/app',
-             'components'=>[]
-         ], $extendConfig);
-         if($dbMock !== null){
-             $config['components']['db'] = $dbMock;
-         }
-         return new Application($config);
-     }
+    }
+
+    protected function prepareTempDir()
+    {
+        FileHelper::removeDirectory(__DIR__ . '/tmp/app');
+        FileHelper::createDirectory(__DIR__ . '/tmp/app');
+        Yii::setAlias('@app', __DIR__ . '/tmp/app');
+    }
+
+    protected function mockApplication(?Connection $dbMock, array $extendConfig = []):Application
+    {
+        $config = ArrayHelper::merge([
+            'id' => 'yii2-openapi-test',
+            'basePath' => __DIR__ . '/tmp/app',
+            'components' => [],
+        ],
+            $extendConfig);
+        if ($dbMock !== null) {
+            $config['components']['db'] = $dbMock;
+        }
+        return new Application($config);
+    }
 
     protected function mockRealApplication($config = [], $appClass = '\yii\console\Application')
     {
@@ -41,7 +55,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
         $schema = $this->createMock(Schema::class);
         $schema->method('getTableSchema')->willReturn(null);
         $schema->method('findUniqueIndexes')->willReturn([]);
-        $schema->method('quoteValue')->willReturnCallback(function($v){ return "'$v'";});
+        $schema->method('quoteValue')->willReturnCallback(function($v) { return "'$v'"; });
         $db = $this->createMock(Connection::class);
         $db->method('getSchema')->willReturn($schema);
         $db->method('getTableSchema')->willReturn(null);

--- a/tests/specs/blog/models/CategoryFaker.php
+++ b/tests/specs/blog/models/CategoryFaker.php
@@ -29,7 +29,7 @@ class CategoryFaker
     public static function makeOne(array $attributes, bool $save = false)
     {
         $model = (new static())->generateModel();
-        $model->setAttributes($attributes);
+        $model->setAttributes($attributes, false);
         if ($save === true) {
             $model->save();
         }

--- a/tests/specs/blog/models/CommentFaker.php
+++ b/tests/specs/blog/models/CommentFaker.php
@@ -29,7 +29,7 @@ class CommentFaker
     public static function makeOne(array $attributes, bool $save = false)
     {
         $model = (new static())->generateModel();
-        $model->setAttributes($attributes);
+        $model->setAttributes($attributes, false);
         if ($save === true) {
             $model->save();
         }

--- a/tests/specs/blog/models/FakerableFaker.php
+++ b/tests/specs/blog/models/FakerableFaker.php
@@ -42,7 +42,7 @@ class FakerableFaker
     public static function makeOne(array $attributes, bool $save = false)
     {
         $model = (new static())->generateModel();
-        $model->setAttributes($attributes);
+        $model->setAttributes($attributes, false);
         if ($save === true) {
             $model->save();
         }

--- a/tests/specs/blog/models/PostFaker.php
+++ b/tests/specs/blog/models/PostFaker.php
@@ -31,7 +31,7 @@ class PostFaker
     public static function makeOne(array $attributes, bool $save = false)
     {
         $model = (new static())->generateModel();
-        $model->setAttributes($attributes);
+        $model->setAttributes($attributes, false);
         if ($save === true) {
             $model->save();
         }

--- a/tests/specs/blog/models/UserFaker.php
+++ b/tests/specs/blog/models/UserFaker.php
@@ -33,7 +33,7 @@ class UserFaker
     public static function makeOne(array $attributes, bool $save = false)
     {
         $model = (new static())->generateModel();
-        $model->setAttributes($attributes);
+        $model->setAttributes($attributes, false);
         if ($save === true) {
             $model->save();
         }

--- a/tests/specs/blog/models/base/Post.php
+++ b/tests/specs/blog/models/base/Post.php
@@ -14,7 +14,7 @@ namespace app\models\base;
  * @property int $created_by_id The User
  *
  * @property \app\models\Category $category
- * @property \app\models\User $created_by
+ * @property \app\models\User $createdBy
  * @property array|\app\models\Comment[] $comments
  */
 abstract class Post extends \yii\db\ActiveRecord

--- a/tests/specs/blog_jsonapi/config/urls.rest.php
+++ b/tests/specs/blog_jsonapi/config/urls.rest.php
@@ -6,9 +6,9 @@
  */
 return [
     'GET me' => 'me/view',
-    'GET auth/password/recovery' => 'auth/view-password-recovery',
+    'GET auth/password/recovery' => 'auth/password-recovery',
     'POST auth/password/recovery' => 'auth/create-password-recovery',
-    'GET auth/password/confirm-recovery/<token:[\w-]+>' => 'auth/view-password-confirm-recovery',
+    'GET auth/password/confirm-recovery/<token:[\w-]+>' => 'auth/password-confirm-recovery',
     'POST auth/new-password' => 'auth/create-new-password',
     'GET categories' => 'category/list',
     'POST categories' => 'category/create',

--- a/tests/specs/blog_jsonapi/controllers/base/AuthController.php
+++ b/tests/specs/blog_jsonapi/controllers/base/AuthController.php
@@ -32,9 +32,9 @@ abstract class AuthController extends JsonApiController
         // TODO implement checkAccess
     }
 
-    public function actionViewPasswordRecovery()
+    public function actionPasswordRecovery()
     {
-        // TODO implement actionViewPasswordRecovery
+        // TODO implement actionPasswordRecovery
     }
 
     public function actionCreatePasswordRecovery()
@@ -42,9 +42,9 @@ abstract class AuthController extends JsonApiController
         // TODO implement actionCreatePasswordRecovery
     }
 
-    public function actionViewPasswordConfirmRecovery($token)
+    public function actionPasswordConfirmRecovery($token)
     {
-        // TODO implement actionViewPasswordConfirmRecovery
+        // TODO implement actionPasswordConfirmRecovery
     }
 
     public function actionCreateNewPassword()

--- a/tests/specs/blog_jsonapi/transformers/PostTransformer.php
+++ b/tests/specs/blog_jsonapi/transformers/PostTransformer.php
@@ -6,7 +6,7 @@ use app\models\Post;
 
 class PostTransformer extends TransformerAbstract
 {
-    protected $availableIncludes = ['category', 'author', 'comments', 'post_tags'];
+    protected $availableIncludes = ['category', 'author', 'comments', 'postTags'];
     protected $defaultIncludes = [];
 
     public function transform(Post $model)

--- a/tests/specs/blog_jsonapi/transformers/TagTransformer.php
+++ b/tests/specs/blog_jsonapi/transformers/TagTransformer.php
@@ -6,7 +6,7 @@ use app\models\Tag;
 
 class TagTransformer extends TransformerAbstract
 {
-    protected $availableIncludes = ['post_tags'];
+    protected $availableIncludes = ['postTags'];
     protected $defaultIncludes = [];
 
     public function transform(Tag $model)

--- a/tests/specs/blog_v2/models/CategoryFaker.php
+++ b/tests/specs/blog_v2/models/CategoryFaker.php
@@ -30,7 +30,7 @@ class CategoryFaker
     public static function makeOne(array $attributes, bool $save = false)
     {
         $model = (new static())->generateModel();
-        $model->setAttributes($attributes);
+        $model->setAttributes($attributes, false);
         if ($save === true) {
             $model->save();
         }

--- a/tests/specs/blog_v2/models/CommentFaker.php
+++ b/tests/specs/blog_v2/models/CommentFaker.php
@@ -29,7 +29,7 @@ class CommentFaker
     public static function makeOne(array $attributes, bool $save = false)
     {
         $model = (new static())->generateModel();
-        $model->setAttributes($attributes);
+        $model->setAttributes($attributes, false);
         if ($save === true) {
             $model->save();
         }

--- a/tests/specs/blog_v2/models/PostFaker.php
+++ b/tests/specs/blog_v2/models/PostFaker.php
@@ -32,7 +32,7 @@ class PostFaker
     public static function makeOne(array $attributes, bool $save = false)
     {
         $model = (new static())->generateModel();
-        $model->setAttributes($attributes);
+        $model->setAttributes($attributes, false);
         if ($save === true) {
             $model->save();
         }

--- a/tests/specs/blog_v2/models/TagFaker.php
+++ b/tests/specs/blog_v2/models/TagFaker.php
@@ -29,7 +29,7 @@ class TagFaker
     public static function makeOne(array $attributes, bool $save = false)
     {
         $model = (new static())->generateModel();
-        $model->setAttributes($attributes);
+        $model->setAttributes($attributes, false);
         if ($save === true) {
             $model->save();
         }

--- a/tests/specs/blog_v2/models/UserFaker.php
+++ b/tests/specs/blog_v2/models/UserFaker.php
@@ -33,7 +33,7 @@ class UserFaker
     public static function makeOne(array $attributes, bool $save = false)
     {
         $model = (new static())->generateModel();
-        $model->setAttributes($attributes);
+        $model->setAttributes($attributes, false);
         if ($save === true) {
             $model->save();
         }

--- a/tests/specs/blog_v2/models/base/Post.php
+++ b/tests/specs/blog_v2/models/base/Post.php
@@ -15,7 +15,7 @@ namespace app\models\base;
  * @property int $created_by_id The User
  *
  * @property \app\models\Category $category
- * @property \app\models\User $created_by
+ * @property \app\models\User $createdBy
  * @property array|\app\models\Comment[] $comments
  * @property array|\app\models\Tag[] $tags
  */

--- a/tests/specs/many2many.php
+++ b/tests/specs/many2many.php
@@ -2,8 +2,9 @@
 return [
     'openApiPath' => '@specs/many2many.yaml',
     'generateUrls' => false,
-    'generateControllers' => false,
+    'generateControllers' => true,
     'generateModels' => true,
+    'useJsonApi' => true,
     'generateMigrations' => true,
     'excludeModels' => [
         'Error',

--- a/tests/specs/many2many.php
+++ b/tests/specs/many2many.php
@@ -1,0 +1,11 @@
+<?php
+return [
+    'openApiPath' => '@specs/many2many.yaml',
+    'generateUrls' => false,
+    'generateControllers' => false,
+    'generateModels' => true,
+    'generateMigrations' => true,
+    'excludeModels' => [
+        'Error',
+    ],
+];

--- a/tests/specs/many2many.yaml
+++ b/tests/specs/many2many.yaml
@@ -40,15 +40,15 @@ components:
         posts_attaches:
           type: array
           items:
-            $ref: '#/components/schemas/junk_PostsAttaches'
+            $ref: '#/components/schemas/junction_PostsAttaches'
         posts_gallery:
           type: array
           items:
-            $ref: '#/components/schemas/junk_PostsGallery'
+            $ref: '#/components/schemas/junction_PostsGallery'
         posts_photos:
           type: array
           items:
-            $ref: '#/components/schemas/junk_Photos2Posts'
+            $ref: '#/components/schemas/junction_Photos2Posts'
     Tag:
       x-table: tags
       required:
@@ -84,17 +84,17 @@ components:
         posts_attaches:
           type: array
           items:
-            $ref: '#/components/schemas/junk_PostsAttaches'
+            $ref: '#/components/schemas/junction_PostsAttaches'
         posts_gallery:
           type: array
           items:
-            $ref: '#/components/schemas/junk_PostsGallery'
+            $ref: '#/components/schemas/junction_PostsGallery'
         photos_posts:
           type: array
           items:
-            $ref: '#/components/schemas/junk_Photos2Posts'
+            $ref: '#/components/schemas/junction_Photos2Posts'
 
-    junk_Photos2Posts:
+    junction_Photos2Posts:
       x-table: photos2posts
       required:
         - id
@@ -108,7 +108,7 @@ components:
         post:
           $ref: '#/components/schemas/Post'
 
-    junk_PostsGallery:
+    junction_PostsGallery:
       x-table: posts_gallery
       properties:
         image:
@@ -118,7 +118,7 @@ components:
         is_cover:
           type: bool
 
-    junk_PostsAttaches:
+    junction_PostsAttaches:
       x-table: posts_attaches
       properties:
         id:

--- a/tests/specs/many2many.yaml
+++ b/tests/specs/many2many.yaml
@@ -33,14 +33,22 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Tag'
-        photos:
+        attaches:
           type: array
           items:
             $ref: '#/components/schemas/Photo'
-        photos2posts:
+        posts_attaches:
           type: array
           items:
-            $ref: '#/components/schemas/Photos2Posts'
+            $ref: '#/components/schemas/junk_PostsAttaches'
+        posts_gallery:
+          type: array
+          items:
+            $ref: '#/components/schemas/junk_PostsGallery'
+        posts_photos:
+          type: array
+          items:
+            $ref: '#/components/schemas/junk_Photos2Posts'
     Tag:
       x-table: tags
       required:
@@ -69,11 +77,24 @@ components:
           readOnly: True
         filename:
           type: string
-        posts:
+        targets:
           type: array
           items:
             $ref: '#/components/schemas/Post'
-    Photos2Posts:
+        posts_attaches:
+          type: array
+          items:
+            $ref: '#/components/schemas/junk_PostsAttaches'
+        posts_gallery:
+          type: array
+          items:
+            $ref: '#/components/schemas/junk_PostsGallery'
+        photos_posts:
+          type: array
+          items:
+            $ref: '#/components/schemas/junk_Photos2Posts'
+
+    junk_Photos2Posts:
       x-table: photos2posts
       required:
         - id
@@ -86,6 +107,29 @@ components:
           $ref: '#/components/schemas/Photo'
         post:
           $ref: '#/components/schemas/Post'
+
+    junk_PostsGallery:
+      x-table: posts_gallery
+      properties:
+        image:
+          $ref: '#/components/schemas/Photo'
+        article:
+          $ref: '#/components/schemas/Post'
+        is_cover:
+          type: bool
+
+    junk_PostsAttaches:
+      x-table: posts_attaches
+      properties:
+        id:
+          type: integer
+          format: int64
+          readOnly: True
+        attach:
+          $ref: '#/components/schemas/Photo'
+        target:
+          $ref: '#/components/schemas/Post'
+
     _PostResource:
       type: object
       properties:

--- a/tests/specs/many2many/controllers/PostController.php
+++ b/tests/specs/many2many/controllers/PostController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace app\controllers;
+
+class PostController extends \app\controllers\base\PostController
+{
+
+    public function actions()
+    {
+        $actions = parent::actions();
+        return $actions;
+    }
+
+
+}
+

--- a/tests/specs/many2many/controllers/base/PostController.php
+++ b/tests/specs/many2many/controllers/base/PostController.php
@@ -1,0 +1,43 @@
+<?php
+namespace app\controllers\base;
+
+use insolita\fractal\JsonApiController;
+use Yii;
+
+abstract class PostController extends JsonApiController
+{
+    public function actions()
+    {
+        return [
+            'list' => [
+                'class' => \insolita\fractal\actions\ListAction::class,
+                'checkAccess' => [$this, 'checkAccess'],
+                'transformer' => \app\transformers\PostTransformer::class,
+                'modelClass' => \app\models\Post::class,
+                'resourceKey' => 'posts',
+                'dataFilter' => null,
+                'prepareDataProvider' => null
+            ],
+            'options' => [
+                'class' => \yii\rest\OptionsAction::class,
+            ],
+        ];
+    }
+
+    /**
+     * Checks the privilege of the current user.
+     *
+     * This method checks whether the current user has the privilege
+     * to run the specified action against the specified data model.
+     * If the user does not have access, a [[ForbiddenHttpException]] should be thrown.
+     *
+     * @param string $action the ID of the action to be executed
+     * @param object $model the model to be accessed. If null, it means no specific model is being accessed.
+     * @param array $params additional parameters
+     * @throws \yii\web\ForbiddenHttpException if the user does not have access
+     */
+    public function checkAccess($action, $model = null, $params = [])
+    {
+        // TODO implement checkAccess
+    }
+}

--- a/tests/specs/many2many/migrations/m200000_000000_create_table_photo.php
+++ b/tests/specs/many2many/migrations/m200000_000000_create_table_photo.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Table for Photo
+ */
+class m200000_000000_create_table_photo extends \yii\db\Migration
+{
+    public function up()
+    {
+        $this->createTable('{{%photo}}', [
+            'id' => $this->bigPrimaryKey(),
+            'filename' => $this->text()->notNull(),
+        ]);
+    }
+
+    public function down()
+    {
+        $this->dropTable('{{%photo}}');
+    }
+}

--- a/tests/specs/many2many/migrations/m200000_000001_create_table_posts.php
+++ b/tests/specs/many2many/migrations/m200000_000001_create_table_posts.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Table for Post
+ */
+class m200000_000001_create_table_posts extends \yii\db\Migration
+{
+    public function up()
+    {
+        $this->createTable('{{%posts}}', [
+            'id' => $this->bigPrimaryKey(),
+            'title' => $this->text()->notNull(),
+        ]);
+    }
+
+    public function down()
+    {
+        $this->dropTable('{{%posts}}');
+    }
+}

--- a/tests/specs/many2many/migrations/m200000_000002_create_table_photos2posts.php
+++ b/tests/specs/many2many/migrations/m200000_000002_create_table_photos2posts.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Table for Photos2Posts
+ */
+class m200000_000002_create_table_photos2posts extends \yii\db\Migration
+{
+    public function up()
+    {
+        $this->createTable('{{%photos2posts}}', [
+            'id' => $this->bigPrimaryKey(),
+            'photo_id' => $this->bigInteger()->null()->defaultValue(null),
+            'post_id' => $this->bigInteger()->null()->defaultValue(null),
+        ]);
+        $this->addForeignKey('fk_photos2posts_photo_id_photo_id', '{{%photos2posts}}', 'photo_id', '{{%photo}}', 'id');
+        $this->addForeignKey('fk_photos2posts_post_id_posts_id', '{{%photos2posts}}', 'post_id', '{{%posts}}', 'id');
+    }
+
+    public function down()
+    {
+        $this->dropForeignKey('fk_photos2posts_post_id_posts_id', '{{%photos2posts}}');
+        $this->dropForeignKey('fk_photos2posts_photo_id_photo_id', '{{%photos2posts}}');
+        $this->dropTable('{{%photos2posts}}');
+    }
+}

--- a/tests/specs/many2many/migrations/m200000_000003_create_table_tags.php
+++ b/tests/specs/many2many/migrations/m200000_000003_create_table_tags.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Table for Tag
+ */
+class m200000_000003_create_table_tags extends \yii\db\Migration
+{
+    public function up()
+    {
+        $this->createTable('{{%tags}}', [
+            'id' => $this->bigPrimaryKey(),
+            'name' => $this->text()->notNull(),
+        ]);
+    }
+
+    public function down()
+    {
+        $this->dropTable('{{%tags}}');
+    }
+}

--- a/tests/specs/many2many/migrations/m200000_000004_create_table_posts2tags.php
+++ b/tests/specs/many2many/migrations/m200000_000004_create_table_posts2tags.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Table for Posts2Tags
+ */
+class m200000_000004_create_table_posts2tags extends \yii\db\Migration
+{
+    public function up()
+    {
+        $this->createTable('{{%posts2tags}}', [
+            'post_id' => $this->bigInteger()->notNull(),
+            'tag_id' => $this->bigInteger()->notNull(),
+        ]);
+        $this->addPrimaryKey('pk_post_id_tag_id', '{{%posts2tags}}', 'post_id,tag_id');
+        $this->addForeignKey('fk_posts2tags_post_id_posts_id', '{{%posts2tags}}', 'post_id', '{{%posts}}', 'id');
+        $this->addForeignKey('fk_posts2tags_tag_id_tags_id', '{{%posts2tags}}', 'tag_id', '{{%tags}}', 'id');
+    }
+
+    public function down()
+    {
+        $this->dropForeignKey('fk_posts2tags_tag_id_tags_id', '{{%posts2tags}}');
+        $this->dropForeignKey('fk_posts2tags_post_id_posts_id', '{{%posts2tags}}');
+        $this->dropPrimaryKey('pk_post_id_tag_id', '{{%posts2tags}}');
+        $this->dropTable('{{%posts2tags}}');
+    }
+}

--- a/tests/specs/many2many/migrations/m200000_000005_create_table_posts_attaches.php
+++ b/tests/specs/many2many/migrations/m200000_000005_create_table_posts_attaches.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Table for PostsAttaches
+ */
+class m200000_000005_create_table_posts_attaches extends \yii\db\Migration
+{
+    public function up()
+    {
+        $this->createTable('{{%posts_attaches}}', [
+            'id' => $this->bigPrimaryKey(),
+            'attach_id' => $this->bigInteger()->null()->defaultValue(null),
+            'target_id' => $this->bigInteger()->null()->defaultValue(null),
+        ]);
+        $this->addForeignKey('fk_posts_attaches_attach_id_photo_id', '{{%posts_attaches}}', 'attach_id', '{{%photo}}', 'id');
+        $this->addForeignKey('fk_posts_attaches_target_id_posts_id', '{{%posts_attaches}}', 'target_id', '{{%posts}}', 'id');
+    }
+
+    public function down()
+    {
+        $this->dropForeignKey('fk_posts_attaches_target_id_posts_id', '{{%posts_attaches}}');
+        $this->dropForeignKey('fk_posts_attaches_attach_id_photo_id', '{{%posts_attaches}}');
+        $this->dropTable('{{%posts_attaches}}');
+    }
+}

--- a/tests/specs/many2many/migrations/m200000_000006_create_table_posts_gallery.php
+++ b/tests/specs/many2many/migrations/m200000_000006_create_table_posts_gallery.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Table for PostsGallery
+ */
+class m200000_000006_create_table_posts_gallery extends \yii\db\Migration
+{
+    public function up()
+    {
+        $this->createTable('{{%posts_gallery}}', [
+            'image_id' => $this->bigInteger()->null()->defaultValue(null),
+            'article_id' => $this->bigInteger()->null()->defaultValue(null),
+            'is_cover' => $this->text()->null()->defaultValue(null),
+        ]);
+        $this->addPrimaryKey('pk_image_id_article_id', '{{%posts_gallery}}', 'image_id,article_id');
+        $this->addForeignKey('fk_posts_gallery_image_id_photo_id', '{{%posts_gallery}}', 'image_id', '{{%photo}}', 'id');
+        $this->addForeignKey('fk_posts_gallery_article_id_posts_id', '{{%posts_gallery}}', 'article_id', '{{%posts}}', 'id');
+    }
+
+    public function down()
+    {
+        $this->dropForeignKey('fk_posts_gallery_article_id_posts_id', '{{%posts_gallery}}');
+        $this->dropForeignKey('fk_posts_gallery_image_id_photo_id', '{{%posts_gallery}}');
+        $this->dropPrimaryKey('pk_image_id_article_id', '{{%posts_gallery}}');
+        $this->dropTable('{{%posts_gallery}}');
+    }
+}

--- a/tests/specs/many2many/models/Photo.php
+++ b/tests/specs/many2many/models/Photo.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace app\models;
+
+class Photo extends \app\models\base\Photo
+{
+
+
+}
+

--- a/tests/specs/many2many/models/PhotoFaker.php
+++ b/tests/specs/many2many/models/PhotoFaker.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace app\models;
+
+use Faker\Factory as FakerFactory;
+use Faker\UniqueGenerator;
+
+/**
+ * Fake data generator for Photo
+ */
+class PhotoFaker
+{
+    public function generateModel()
+    {
+        $faker = FakerFactory::create(str_replace('-', '_', \Yii::$app->language));
+        $uniqueFaker = new UniqueGenerator($faker);
+        $model = new Photo();
+        //$model->id = $uniqueFaker->numberBetween(0, 2147483647);
+        $model->filename = $faker->sentence;
+        return $model;
+    }
+
+    /**
+     * @param array $attributes
+     * @param bool  $save
+     * @return \yii\db\ActiveRecordInterface
+     */
+    public static function makeOne(array $attributes, bool $save = false)
+    {
+        $model = (new static())->generateModel();
+        $model->setAttributes($attributes, false);
+        if ($save === true) {
+            $model->save();
+        }
+        return $model;
+    }
+
+    /**
+     * @param       $number
+     * @param array $commonAttributes
+     * @param bool  $save
+     * @return \yii\db\ActiveRecordInterface[]|array
+     * @example TaskFaker::make(5, ['project_id'=>1, 'user_id' => 2]);
+     */
+    public static function make($number, array $commonAttributes, bool $save = false):array
+    {
+        if ($number < 1) {
+            return [];
+        }
+        return array_map(function () use ($commonAttributes, $save) {
+            return static::makeOne($commonAttributes, $save);
+        }, range(0, $number -1));
+    }
+}

--- a/tests/specs/many2many/models/Photos2Posts.php
+++ b/tests/specs/many2many/models/Photos2Posts.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace app\models;
+
+class Photos2Posts extends \app\models\base\Photos2Posts
+{
+
+
+}
+

--- a/tests/specs/many2many/models/Photos2PostsFaker.php
+++ b/tests/specs/many2many/models/Photos2PostsFaker.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace app\models;
+
+use Faker\Factory as FakerFactory;
+use Faker\UniqueGenerator;
+
+/**
+ * Fake data generator for Photos2Posts
+ */
+class Photos2PostsFaker
+{
+    public function generateModel()
+    {
+        $faker = FakerFactory::create(str_replace('-', '_', \Yii::$app->language));
+        $uniqueFaker = new UniqueGenerator($faker);
+        $model = new Photos2Posts();
+        //$model->id = $uniqueFaker->numberBetween(0, 2147483647);
+        return $model;
+    }
+
+    /**
+     * @param array $attributes
+     * @param bool  $save
+     * @return \yii\db\ActiveRecordInterface
+     */
+    public static function makeOne(array $attributes, bool $save = false)
+    {
+        $model = (new static())->generateModel();
+        $model->setAttributes($attributes, false);
+        if ($save === true) {
+            $model->save();
+        }
+        return $model;
+    }
+
+    /**
+     * @param       $number
+     * @param array $commonAttributes
+     * @param bool  $save
+     * @return \yii\db\ActiveRecordInterface[]|array
+     * @example TaskFaker::make(5, ['project_id'=>1, 'user_id' => 2]);
+     */
+    public static function make($number, array $commonAttributes, bool $save = false):array
+    {
+        if ($number < 1) {
+            return [];
+        }
+        return array_map(function () use ($commonAttributes, $save) {
+            return static::makeOne($commonAttributes, $save);
+        }, range(0, $number -1));
+    }
+}

--- a/tests/specs/many2many/models/Post.php
+++ b/tests/specs/many2many/models/Post.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace app\models;
+
+class Post extends \app\models\base\Post
+{
+
+
+}
+

--- a/tests/specs/many2many/models/PostFaker.php
+++ b/tests/specs/many2many/models/PostFaker.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace app\models;
+
+use Faker\Factory as FakerFactory;
+use Faker\UniqueGenerator;
+
+/**
+ * Fake data generator for Post
+ */
+class PostFaker
+{
+    public function generateModel()
+    {
+        $faker = FakerFactory::create(str_replace('-', '_', \Yii::$app->language));
+        $uniqueFaker = new UniqueGenerator($faker);
+        $model = new Post();
+        //$model->id = $uniqueFaker->numberBetween(0, 2147483647);
+        $model->title = $faker->sentence;
+        return $model;
+    }
+
+    /**
+     * @param array $attributes
+     * @param bool  $save
+     * @return \yii\db\ActiveRecordInterface
+     */
+    public static function makeOne(array $attributes, bool $save = false)
+    {
+        $model = (new static())->generateModel();
+        $model->setAttributes($attributes, false);
+        if ($save === true) {
+            $model->save();
+        }
+        return $model;
+    }
+
+    /**
+     * @param       $number
+     * @param array $commonAttributes
+     * @param bool  $save
+     * @return \yii\db\ActiveRecordInterface[]|array
+     * @example TaskFaker::make(5, ['project_id'=>1, 'user_id' => 2]);
+     */
+    public static function make($number, array $commonAttributes, bool $save = false):array
+    {
+        if ($number < 1) {
+            return [];
+        }
+        return array_map(function () use ($commonAttributes, $save) {
+            return static::makeOne($commonAttributes, $save);
+        }, range(0, $number -1));
+    }
+}

--- a/tests/specs/many2many/models/PostsAttaches.php
+++ b/tests/specs/many2many/models/PostsAttaches.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace app\models;
+
+class PostsAttaches extends \app\models\base\PostsAttaches
+{
+
+
+}
+

--- a/tests/specs/many2many/models/PostsAttachesFaker.php
+++ b/tests/specs/many2many/models/PostsAttachesFaker.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace app\models;
+
+use Faker\Factory as FakerFactory;
+use Faker\UniqueGenerator;
+
+/**
+ * Fake data generator for PostsAttaches
+ */
+class PostsAttachesFaker
+{
+    public function generateModel()
+    {
+        $faker = FakerFactory::create(str_replace('-', '_', \Yii::$app->language));
+        $uniqueFaker = new UniqueGenerator($faker);
+        $model = new PostsAttaches();
+        //$model->id = $uniqueFaker->numberBetween(0, 2147483647);
+        return $model;
+    }
+
+    /**
+     * @param array $attributes
+     * @param bool  $save
+     * @return \yii\db\ActiveRecordInterface
+     */
+    public static function makeOne(array $attributes, bool $save = false)
+    {
+        $model = (new static())->generateModel();
+        $model->setAttributes($attributes, false);
+        if ($save === true) {
+            $model->save();
+        }
+        return $model;
+    }
+
+    /**
+     * @param       $number
+     * @param array $commonAttributes
+     * @param bool  $save
+     * @return \yii\db\ActiveRecordInterface[]|array
+     * @example TaskFaker::make(5, ['project_id'=>1, 'user_id' => 2]);
+     */
+    public static function make($number, array $commonAttributes, bool $save = false):array
+    {
+        if ($number < 1) {
+            return [];
+        }
+        return array_map(function () use ($commonAttributes, $save) {
+            return static::makeOne($commonAttributes, $save);
+        }, range(0, $number -1));
+    }
+}

--- a/tests/specs/many2many/models/PostsGallery.php
+++ b/tests/specs/many2many/models/PostsGallery.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace app\models;
+
+class PostsGallery extends \app\models\base\PostsGallery
+{
+
+
+}
+

--- a/tests/specs/many2many/models/PostsGalleryFaker.php
+++ b/tests/specs/many2many/models/PostsGalleryFaker.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace app\models;
+
+use Faker\Factory as FakerFactory;
+use Faker\UniqueGenerator;
+
+/**
+ * Fake data generator for PostsGallery
+ */
+class PostsGalleryFaker
+{
+    public function generateModel()
+    {
+        $faker = FakerFactory::create(str_replace('-', '_', \Yii::$app->language));
+        $uniqueFaker = new UniqueGenerator($faker);
+        $model = new PostsGallery();
+        $model->is_cover = $faker->boolean;
+        return $model;
+    }
+
+    /**
+     * @param array $attributes
+     * @param bool  $save
+     * @return \yii\db\ActiveRecordInterface
+     */
+    public static function makeOne(array $attributes, bool $save = false)
+    {
+        $model = (new static())->generateModel();
+        $model->setAttributes($attributes, false);
+        if ($save === true) {
+            $model->save();
+        }
+        return $model;
+    }
+
+    /**
+     * @param       $number
+     * @param array $commonAttributes
+     * @param bool  $save
+     * @return \yii\db\ActiveRecordInterface[]|array
+     * @example TaskFaker::make(5, ['project_id'=>1, 'user_id' => 2]);
+     */
+    public static function make($number, array $commonAttributes, bool $save = false):array
+    {
+        if ($number < 1) {
+            return [];
+        }
+        return array_map(function () use ($commonAttributes, $save) {
+            return static::makeOne($commonAttributes, $save);
+        }, range(0, $number -1));
+    }
+}

--- a/tests/specs/many2many/models/Tag.php
+++ b/tests/specs/many2many/models/Tag.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace app\models;
+
+class Tag extends \app\models\base\Tag
+{
+
+
+}
+

--- a/tests/specs/many2many/models/TagFaker.php
+++ b/tests/specs/many2many/models/TagFaker.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace app\models;
+
+use Faker\Factory as FakerFactory;
+use Faker\UniqueGenerator;
+
+/**
+ * Fake data generator for Tag
+ */
+class TagFaker
+{
+    public function generateModel()
+    {
+        $faker = FakerFactory::create(str_replace('-', '_', \Yii::$app->language));
+        $uniqueFaker = new UniqueGenerator($faker);
+        $model = new Tag();
+        //$model->id = $uniqueFaker->numberBetween(0, 2147483647);
+        $model->name = $faker->sentence;
+        return $model;
+    }
+
+    /**
+     * @param array $attributes
+     * @param bool  $save
+     * @return \yii\db\ActiveRecordInterface
+     */
+    public static function makeOne(array $attributes, bool $save = false)
+    {
+        $model = (new static())->generateModel();
+        $model->setAttributes($attributes, false);
+        if ($save === true) {
+            $model->save();
+        }
+        return $model;
+    }
+
+    /**
+     * @param       $number
+     * @param array $commonAttributes
+     * @param bool  $save
+     * @return \yii\db\ActiveRecordInterface[]|array
+     * @example TaskFaker::make(5, ['project_id'=>1, 'user_id' => 2]);
+     */
+    public static function make($number, array $commonAttributes, bool $save = false):array
+    {
+        if ($number < 1) {
+            return [];
+        }
+        return array_map(function () use ($commonAttributes, $save) {
+            return static::makeOne($commonAttributes, $save);
+        }, range(0, $number -1));
+    }
+}

--- a/tests/specs/many2many/models/base/Photo.php
+++ b/tests/specs/many2many/models/base/Photo.php
@@ -33,12 +33,12 @@ abstract class Photo extends \yii\db\ActiveRecord
 
     public function getPostsAttaches()
     {
-        return $this->hasMany(\app\models\PostsAttaches::class, ['photo_id' => 'id']);
+        return $this->hasMany(\app\models\PostsAttaches::class, ['attach_id' => 'id']);
     }
 
     public function getPostsGallery()
     {
-        return $this->hasMany(\app\models\PostsGallery::class, ['photo_id' => 'id']);
+        return $this->hasMany(\app\models\PostsGallery::class, ['image_id' => 'id']);
     }
 
     public function getPhotosPosts()
@@ -48,13 +48,13 @@ abstract class Photo extends \yii\db\ActiveRecord
 
     public function getTargets()
     {
-        return $this->hasMany(\app\models\Post::class, ['id' => 'post_id'])
+        return $this->hasMany(\app\models\Post::class, ['id' => 'target_id'])
                     ->via('postsAttaches');
     }
 
     public function getArticles()
     {
-        return $this->hasMany(\app\models\Post::class, ['id' => 'post_id'])
+        return $this->hasMany(\app\models\Post::class, ['id' => 'article_id'])
                     ->via('postsGallery');
     }
 

--- a/tests/specs/many2many/models/base/Photo.php
+++ b/tests/specs/many2many/models/base/Photo.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace app\models\base;
+
+/**
+ *
+ *
+ * @property int $id
+ * @property string $filename
+ *
+ * @property array|\app\models\PostsAttaches[] $postsAttaches
+ * @property array|\app\models\PostsGallery[] $postsGallery
+ * @property array|\app\models\Photos2Posts[] $photosPosts
+ * @property array|\app\models\Post[] $targets
+ * @property array|\app\models\Post[] $articles
+ * @property array|\app\models\Post[] $posts
+ */
+abstract class Photo extends \yii\db\ActiveRecord
+{
+    public static function tableName()
+    {
+        return '{{%photo}}';
+    }
+
+    public function rules()
+    {
+        return [
+            'trim' => [['filename'], 'trim'],
+            'required' => [['filename'], 'required'],
+            'filename_string' => [['filename'], 'string'],
+        ];
+    }
+
+    public function getPostsAttaches()
+    {
+        return $this->hasMany(\app\models\PostsAttaches::class, ['photo_id' => 'id']);
+    }
+
+    public function getPostsGallery()
+    {
+        return $this->hasMany(\app\models\PostsGallery::class, ['photo_id' => 'id']);
+    }
+
+    public function getPhotosPosts()
+    {
+        return $this->hasMany(\app\models\Photos2Posts::class, ['photo_id' => 'id']);
+    }
+
+    public function getTargets()
+    {
+        return $this->hasMany(\app\models\Post::class, ['id' => 'post_id'])
+                    ->via('postsAttaches');
+    }
+
+    public function getArticles()
+    {
+        return $this->hasMany(\app\models\Post::class, ['id' => 'post_id'])
+                    ->via('postsGallery');
+    }
+
+    public function getPosts()
+    {
+        return $this->hasMany(\app\models\Post::class, ['id' => 'post_id'])
+                    ->via('photosPosts');
+    }
+}

--- a/tests/specs/many2many/models/base/Photos2Posts.php
+++ b/tests/specs/many2many/models/base/Photos2Posts.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace app\models\base;
+
+/**
+ *
+ *
+ * @property int $id
+ * @property int $photo_id
+ * @property int $post_id
+ *
+ * @property \app\models\Photo $photo
+ * @property \app\models\Post $post
+ */
+abstract class Photos2Posts extends \yii\db\ActiveRecord
+{
+    public static function tableName()
+    {
+        return '{{%photos2posts}}';
+    }
+
+    public function rules()
+    {
+        return [
+            'photo_id_integer' => [['photo_id'], 'integer'],
+            'photo_id_exist' => [['photo_id'], 'exist', 'targetRelation' => 'Photo'],
+            'post_id_integer' => [['post_id'], 'integer'],
+            'post_id_exist' => [['post_id'], 'exist', 'targetRelation' => 'Post'],
+        ];
+    }
+
+    public function getPhoto()
+    {
+        return $this->hasOne(\app\models\Photo::class, ['id' => 'photo_id']);
+    }
+
+    public function getPost()
+    {
+        return $this->hasOne(\app\models\Post::class, ['id' => 'post_id']);
+    }
+}

--- a/tests/specs/many2many/models/base/Post.php
+++ b/tests/specs/many2many/models/base/Post.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace app\models\base;
+
+/**
+ * A blog post
+ *
+ * @property int $id
+ * @property string $title
+ *
+ * @property array|\app\models\PostsAttaches[] $postsAttaches
+ * @property array|\app\models\PostsGallery[] $postsGallery
+ * @property array|\app\models\Photos2Posts[] $postsPhotos
+ * @property array|\app\models\Tag[] $tags
+ * @property array|\app\models\Photo[] $attaches
+ * @property array|\app\models\Photo[] $images
+ * @property array|\app\models\Photo[] $photos
+ */
+abstract class Post extends \yii\db\ActiveRecord
+{
+    public static function tableName()
+    {
+        return '{{%posts}}';
+    }
+
+    public function rules()
+    {
+        return [
+            'trim' => [['title'], 'trim'],
+            'required' => [['title'], 'required'],
+            'title_string' => [['title'], 'string'],
+        ];
+    }
+
+    public function getPostsAttaches()
+    {
+        return $this->hasMany(\app\models\PostsAttaches::class, ['post_id' => 'id']);
+    }
+
+    public function getPostsGallery()
+    {
+        return $this->hasMany(\app\models\PostsGallery::class, ['post_id' => 'id']);
+    }
+
+    public function getPostsPhotos()
+    {
+        return $this->hasMany(\app\models\Photos2Posts::class, ['post_id' => 'id']);
+    }
+
+    public function getTags()
+    {
+        return $this->hasMany(\app\models\Tag::class, ['id' => 'tag_id'])
+                    ->viaTable('posts2tags', ['post_id' => 'id']);
+    }
+
+    public function getAttaches()
+    {
+        return $this->hasMany(\app\models\Photo::class, ['id' => 'photo_id'])
+                    ->via('postsAttaches');
+    }
+
+    public function getImages()
+    {
+        return $this->hasMany(\app\models\Photo::class, ['id' => 'photo_id'])
+                    ->via('postsGallery');
+    }
+
+    public function getPhotos()
+    {
+        return $this->hasMany(\app\models\Photo::class, ['id' => 'photo_id'])
+                    ->via('postsPhotos');
+    }
+}

--- a/tests/specs/many2many/models/base/Post.php
+++ b/tests/specs/many2many/models/base/Post.php
@@ -34,12 +34,12 @@ abstract class Post extends \yii\db\ActiveRecord
 
     public function getPostsAttaches()
     {
-        return $this->hasMany(\app\models\PostsAttaches::class, ['post_id' => 'id']);
+        return $this->hasMany(\app\models\PostsAttaches::class, ['target_id' => 'id']);
     }
 
     public function getPostsGallery()
     {
-        return $this->hasMany(\app\models\PostsGallery::class, ['post_id' => 'id']);
+        return $this->hasMany(\app\models\PostsGallery::class, ['article_id' => 'id']);
     }
 
     public function getPostsPhotos()
@@ -55,13 +55,13 @@ abstract class Post extends \yii\db\ActiveRecord
 
     public function getAttaches()
     {
-        return $this->hasMany(\app\models\Photo::class, ['id' => 'photo_id'])
+        return $this->hasMany(\app\models\Photo::class, ['id' => 'attach_id'])
                     ->via('postsAttaches');
     }
 
     public function getImages()
     {
-        return $this->hasMany(\app\models\Photo::class, ['id' => 'photo_id'])
+        return $this->hasMany(\app\models\Photo::class, ['id' => 'image_id'])
                     ->via('postsGallery');
     }
 

--- a/tests/specs/many2many/models/base/PostsAttaches.php
+++ b/tests/specs/many2many/models/base/PostsAttaches.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace app\models\base;
+
+/**
+ *
+ *
+ * @property int $id
+ * @property int $attach_id
+ * @property int $target_id
+ *
+ * @property \app\models\Photo $attach
+ * @property \app\models\Post $target
+ */
+abstract class PostsAttaches extends \yii\db\ActiveRecord
+{
+    public static function tableName()
+    {
+        return '{{%posts_attaches}}';
+    }
+
+    public function rules()
+    {
+        return [
+            'attach_id_integer' => [['attach_id'], 'integer'],
+            'attach_id_exist' => [['attach_id'], 'exist', 'targetRelation' => 'Attach'],
+            'target_id_integer' => [['target_id'], 'integer'],
+            'target_id_exist' => [['target_id'], 'exist', 'targetRelation' => 'Target'],
+        ];
+    }
+
+    public function getAttach()
+    {
+        return $this->hasOne(\app\models\Photo::class, ['id' => 'attach_id']);
+    }
+
+    public function getTarget()
+    {
+        return $this->hasOne(\app\models\Post::class, ['id' => 'target_id']);
+    }
+}

--- a/tests/specs/many2many/models/base/PostsGallery.php
+++ b/tests/specs/many2many/models/base/PostsGallery.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace app\models\base;
+
+/**
+ *
+ *
+ * @property int $image_id
+ * @property int $article_id
+ * @property bool $is_cover
+ *
+ * @property \app\models\Photo $image
+ * @property \app\models\Post $article
+ */
+abstract class PostsGallery extends \yii\db\ActiveRecord
+{
+    public static function tableName()
+    {
+        return '{{%posts_gallery}}';
+    }
+
+    public function rules()
+    {
+        return [
+            'image_id_integer' => [['image_id'], 'integer'],
+            'image_id_exist' => [['image_id'], 'exist', 'targetRelation' => 'Image'],
+            'article_id_integer' => [['article_id'], 'integer'],
+            'article_id_exist' => [['article_id'], 'exist', 'targetRelation' => 'Article'],
+            'is_cover_boolean' => [['is_cover'], 'boolean'],
+        ];
+    }
+
+    public function getImage()
+    {
+        return $this->hasOne(\app\models\Photo::class, ['id' => 'image_id']);
+    }
+
+    public function getArticle()
+    {
+        return $this->hasOne(\app\models\Post::class, ['id' => 'article_id']);
+    }
+}

--- a/tests/specs/many2many/models/base/Tag.php
+++ b/tests/specs/many2many/models/base/Tag.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace app\models\base;
+
+/**
+ *
+ *
+ * @property int $id
+ * @property string $name
+ *
+ * @property array|\app\models\Post[] $posts
+ */
+abstract class Tag extends \yii\db\ActiveRecord
+{
+    public static function tableName()
+    {
+        return '{{%tags}}';
+    }
+
+    public function rules()
+    {
+        return [
+            'trim' => [['name'], 'trim'],
+            'required' => [['name'], 'required'],
+            'name_string' => [['name'], 'string'],
+        ];
+    }
+
+    public function getPosts()
+    {
+        return $this->hasMany(\app\models\Post::class, ['id' => 'post_id'])
+                    ->viaTable('posts2tags', ['tag_id' => 'id']);
+    }
+}

--- a/tests/specs/many2many/transformers/PostTransformer.php
+++ b/tests/specs/many2many/transformers/PostTransformer.php
@@ -1,0 +1,65 @@
+<?php
+namespace app\transformers;
+
+use League\Fractal\TransformerAbstract;
+use app\models\Post;
+
+class PostTransformer extends TransformerAbstract
+{
+    protected $availableIncludes = ['postsAttaches', 'postsGallery', 'postsPhotos', 'tags', 'attaches', 'images', 'photos'];
+    protected $defaultIncludes = [];
+
+    public function transform(Post $model)
+    {
+        return $model->getAttributes();
+    }
+
+    public function includePostsAttaches(Post $model)
+    {
+        $relation = $model->postsAttaches;
+        $transformer = new PostsAttachTransformer();
+        return $this->collection($relation, $transformer, 'posts-attaches');
+    }
+
+    public function includePostsGallery(Post $model)
+    {
+        $relation = $model->postsGallery;
+        $transformer = new PostsGalleryTransformer();
+        return $this->collection($relation, $transformer, 'posts-galleries');
+    }
+
+    public function includePostsPhotos(Post $model)
+    {
+        $relation = $model->postsPhotos;
+        $transformer = new Photos2PostTransformer();
+        return $this->collection($relation, $transformer, 'photos2-posts');
+    }
+
+    public function includeTags(Post $model)
+    {
+        $relation = $model->tags;
+        $transformer = new TagTransformer();
+        return $this->collection($relation, $transformer, 'tags');
+    }
+
+    public function includeAttaches(Post $model)
+    {
+        $relation = $model->attaches;
+        $transformer = new PhotoTransformer();
+        return $this->collection($relation, $transformer, 'photos');
+    }
+
+    public function includeImages(Post $model)
+    {
+        $relation = $model->images;
+        $transformer = new PhotoTransformer();
+        return $this->collection($relation, $transformer, 'photos');
+    }
+
+    public function includePhotos(Post $model)
+    {
+        $relation = $model->photos;
+        $transformer = new PhotoTransformer();
+        return $this->collection($relation, $transformer, 'photos');
+    }
+}

--- a/tests/specs/menu/models/MenuFaker.php
+++ b/tests/specs/menu/models/MenuFaker.php
@@ -30,7 +30,7 @@ class MenuFaker
     public static function makeOne(array $attributes, bool $save = false)
     {
         $model = (new static())->generateModel();
-        $model->setAttributes($attributes);
+        $model->setAttributes($attributes, false);
         if ($save === true) {
             $model->save();
         }

--- a/tests/specs/petstore/models/PetFaker.php
+++ b/tests/specs/petstore/models/PetFaker.php
@@ -29,7 +29,7 @@ class PetFaker
     public static function makeOne(array $attributes, bool $save = false)
     {
         $model = (new static())->generateModel();
-        $model->setAttributes($attributes);
+        $model->setAttributes($attributes, false);
         if ($save === true) {
             $model->save();
         }

--- a/tests/specs/petstore/models/StoreFaker.php
+++ b/tests/specs/petstore/models/StoreFaker.php
@@ -28,7 +28,7 @@ class StoreFaker
     public static function makeOne(array $attributes, bool $save = false)
     {
         $model = (new static())->generateModel();
-        $model->setAttributes($attributes);
+        $model->setAttributes($attributes, false);
         if ($save === true) {
             $model->save();
         }

--- a/tests/specs/petstore_arrayref/models/PetFaker.php
+++ b/tests/specs/petstore_arrayref/models/PetFaker.php
@@ -29,7 +29,7 @@ class PetFaker
     public static function makeOne(array $attributes, bool $save = false)
     {
         $model = (new static())->generateModel();
-        $model->setAttributes($attributes);
+        $model->setAttributes($attributes, false);
         if ($save === true) {
             $model->save();
         }

--- a/tests/specs/petstore_jsonapi/models/PetFaker.php
+++ b/tests/specs/petstore_jsonapi/models/PetFaker.php
@@ -29,7 +29,7 @@ class PetFaker
     public static function makeOne(array $attributes, bool $save = false)
     {
         $model = (new static())->generateModel();
-        $model->setAttributes($attributes);
+        $model->setAttributes($attributes, false);
         if ($save === true) {
             $model->save();
         }

--- a/tests/specs/petstore_namespace/mymodels/faker/PetFaker.php
+++ b/tests/specs/petstore_namespace/mymodels/faker/PetFaker.php
@@ -30,7 +30,7 @@ class PetFaker
     public static function makeOne(array $attributes, bool $save = false)
     {
         $model = (new static())->generateModel();
-        $model->setAttributes($attributes);
+        $model->setAttributes($attributes, false);
         if ($save === true) {
             $model->save();
         }

--- a/tests/specs/petstore_namespace/mymodels/faker/StoreFaker.php
+++ b/tests/specs/petstore_namespace/mymodels/faker/StoreFaker.php
@@ -29,7 +29,7 @@ class StoreFaker
     public static function makeOne(array $attributes, bool $save = false)
     {
         $model = (new static())->generateModel();
-        $model->setAttributes($attributes);
+        $model->setAttributes($attributes, false);
         if ($save === true) {
             $model->save();
         }

--- a/tests/specs/petstore_xtable/models/PetFaker.php
+++ b/tests/specs/petstore_xtable/models/PetFaker.php
@@ -29,7 +29,7 @@ class PetFaker
     public static function makeOne(array $attributes, bool $save = false)
     {
         $model = (new static())->generateModel();
-        $model->setAttributes($attributes);
+        $model->setAttributes($attributes, false);
         if ($save === true) {
             $model->save();
         }

--- a/tests/specs/postgres_custom/models/CustomFaker.php
+++ b/tests/specs/postgres_custom/models/CustomFaker.php
@@ -33,7 +33,7 @@ class CustomFaker
     public static function makeOne(array $attributes, bool $save = false)
     {
         $model = (new static())->generateModel();
-        $model->setAttributes($attributes);
+        $model->setAttributes($attributes, false);
         if ($save === true) {
             $model->save();
         }

--- a/tests/unit/AttributeResolverTest.php
+++ b/tests/unit/AttributeResolverTest.php
@@ -7,6 +7,7 @@ use cebe\openapi\spec\OpenApi;
 use cebe\openapi\spec\Schema;
 use cebe\yii2openapi\lib\AttributeResolver;
 use cebe\yii2openapi\lib\items\DbModel;
+use cebe\yii2openapi\lib\items\JunctionSchemas;
 use cebe\yii2openapi\lib\items\ManyToManyRelation;
 use tests\TestCase;
 use Yii;
@@ -18,7 +19,8 @@ class AttributeResolverTest extends TestCase
     {
         $schemaFile = Yii::getAlias("@specs/many2many.yaml");
         $openApi = Reader::readFromYamlFile($schemaFile, OpenApi::class, false);
-        $postModel = (new AttributeResolver('Post', $openApi->components->schemas['Post']))->resolve();
+        $postModel = (new AttributeResolver('Post', $openApi->components->schemas['Post'], new JunctionSchemas([])))
+            ->resolve();
         self::assertNotEmpty($postModel->many2many);
         $relation = $postModel->many2many['tags'];
         self::assertInstanceOf(ManyToManyRelation::class, $relation);
@@ -29,7 +31,8 @@ class AttributeResolverTest extends TestCase
         self::assertEquals(['id' => 'tag_id'], $relation->getLink());
         self::assertEquals(['post_id' => 'id'], $relation->getViaLink());
 
-        $tagModel = (new AttributeResolver('Tag', $openApi->components->schemas['Tag']))->resolve();
+        $tagModel = (new AttributeResolver('Tag', $openApi->components->schemas['Tag'], new JunctionSchemas([])))
+            ->resolve();
         self::assertNotEmpty($tagModel->many2many);
         $relation = $tagModel->many2many['posts'];
         self::assertInstanceOf(ManyToManyRelation::class, $relation);
@@ -39,7 +42,10 @@ class AttributeResolverTest extends TestCase
         self::assertEquals('posts2tags', $relation->getViaTableName());
         self::assertEquals(['id' => 'post_id'], $relation->getLink());
         self::assertEquals(['tag_id' => 'id'], $relation->getViaLink());
+
+
     }
+
     /**
      * @dataProvider dataProvider
      * @param string                              $schemaName
@@ -48,18 +54,18 @@ class AttributeResolverTest extends TestCase
      */
     public function testResolve(string $schemaName, Schema $schema, DbModel $expected):void
     {
-        $resolver = new AttributeResolver($schemaName, $schema);
+        $resolver = new AttributeResolver($schemaName, $schema, new JunctionSchemas([]));
         $model = $resolver->resolve();
-        echo $schemaName.PHP_EOL;
+        echo $schemaName . PHP_EOL;
         self::assertEquals($expected->name, $model->name);
         self::assertEquals($expected->tableName, $model->tableName);
         self::assertEquals($expected->description, $model->description);
         self::assertEquals($expected->tableAlias, $model->tableAlias);
-        foreach ($model->relations as $name => $relation){
+        foreach ($model->relations as $name => $relation) {
             self::assertTrue(isset($expected->relations[$name]));
             self::assertEquals($expected->relations[$name], $relation);
         }
-        foreach ($model->attributes as $name => $attribute){
+        foreach ($model->attributes as $name => $attribute) {
             self::assertTrue(isset($expected->attributes[$name]));
             self::assertEquals($expected->attributes[$name], $attribute);
         }
@@ -74,22 +80,22 @@ class AttributeResolverTest extends TestCase
             [
                 'User',
                 $openApi->components->schemas['User'],
-                $fixture['user']
+                $fixture['user'],
             ],
             [
                 'Category',
                 $openApi->components->schemas['Category'],
-                $fixture['category']
+                $fixture['category'],
             ],
             [
                 'Post',
                 $openApi->components->schemas['Post'],
-                $fixture['post']
+                $fixture['post'],
             ],
             [
                 'Comment',
                 $openApi->components->schemas['Comment'],
-                $fixture['comment']
+                $fixture['comment'],
             ],
         ];
     }

--- a/tests/unit/FractalGeneratorTest.php
+++ b/tests/unit/FractalGeneratorTest.php
@@ -70,7 +70,7 @@ class FractalGeneratorTest extends TestCase
                 'relatedModel' => null
             ]),
             new FractalAction([
-                'id' => 'view-password-recovery',
+                'id' => 'password-recovery',
                 'type' => RouteData::TYPE_DEFAULT,
                 'urlPath' => '/auth/password/recovery',
                 'requestMethod' => 'GET',
@@ -102,7 +102,7 @@ class FractalGeneratorTest extends TestCase
                 'relatedModel' => null
             ]),
             new FractalAction([
-                'id' => 'view-password-confirm-recovery',
+                'id' => 'password-confirm-recovery',
                 'type' => RouteData::TYPE_DEFAULT,
                 'urlPath' => '/auth/password/confirm-recovery/{token}',
                 'requestMethod' => 'GET',

--- a/tests/unit/SchemaToDatabaseTest.php
+++ b/tests/unit/SchemaToDatabaseTest.php
@@ -23,25 +23,25 @@ class SchemaToDatabaseTest extends TestCase
         VarDumper::dump($result->indexByJunctionSchema());
         self::assertInstanceOf(JunctionSchemas::class, $result);
         self::assertEqualsCanonicalizing(
-            ['junk_Photos2Posts', 'junk_PostsGallery', 'junk_PostsAttaches'],
+            ['junction_Photos2Posts', 'junction_PostsGallery', 'junction_PostsAttaches'],
             array_keys($result->indexByJunctionSchema())
         );
         self::assertEqualsCanonicalizing(
             ['Post', 'Photo'],
             array_keys($result->indexByClassSchema())
         );
-        self::assertEquals('junk_PostAttaches', $result->addPrefix('PostAttaches'));
-        self::assertEquals('PostAttaches', $result->trimPrefix('junk_PostAttaches'));
+        self::assertEquals('junction_PostAttaches', $result->addPrefix('PostAttaches'));
+        self::assertEquals('PostAttaches', $result->trimPrefix('junction_PostAttaches'));
         self::assertTrue($result->isJunctionSchema('PostsAttaches'));
-        self::assertTrue($result->isJunctionSchema('junk_PostsAttaches'));
+        self::assertTrue($result->isJunctionSchema('junction_PostsAttaches'));
         self::assertTrue($result->isManyToManyProperty('Post', 'image'));
         self::assertTrue($result->isManyToManyProperty('Post', 'photo'));
         self::assertTrue($result->isManyToManyProperty('Photo', 'article'));
         self::assertTrue($result->isManyToManyProperty('Photo', 'post'));
-        self::assertTrue($result->isJunctionProperty('junk_PostsGallery', 'image'));
+        self::assertTrue($result->isJunctionProperty('junction_PostsGallery', 'image'));
         self::assertTrue($result->isJunctionProperty('PostsGallery', 'article'));
-        self::assertTrue($result->isJunctionProperty('junk_Photos2Posts', 'photo'));
-        self::assertTrue($result->isJunctionProperty('junk_Photos2Posts', 'post'));
+        self::assertTrue($result->isJunctionProperty('junction_Photos2Posts', 'photo'));
+        self::assertTrue($result->isJunctionProperty('junction_Photos2Posts', 'post'));
         self::assertTrue($result->isJunctionProperty('Photos2Posts', 'post'));
         self::assertTrue($result->isJunctionRef('Photo', 'posts_gallery'));
         self::assertTrue($result->isJunctionRef('Photo', 'posts_attaches'));

--- a/tests/unit/SchemaToDatabaseTest.php
+++ b/tests/unit/SchemaToDatabaseTest.php
@@ -5,32 +5,99 @@ namespace tests\unit;
 use cebe\openapi\Reader;
 use cebe\openapi\spec\OpenApi;
 use cebe\yii2openapi\lib\items\DbModel;
+use cebe\yii2openapi\lib\items\JunctionSchemas;
 use cebe\yii2openapi\lib\SchemaToDatabase;
 use tests\TestCase;
 use Yii;
+use yii\helpers\VarDumper;
+use function array_keys;
 
 class SchemaToDatabaseTest extends TestCase
 {
-     public function testGenerateModels()
-     {
-         $schemaFile = Yii::getAlias("@specs/many2many.yaml");
-         $openApi = Reader::readFromYamlFile($schemaFile, OpenApi::class, false);
-         $converter = new SchemaToDatabase([]);
-         $result = $converter->generateModels($openApi);
-         self::assertNotEmpty($result);
-         self::assertArrayHasKey('Post', $result);
-         self::assertArrayHasKey('Tag', $result);
-         self::assertArrayHasKey('Photo', $result);
-         self::assertArrayHasKey('Photos2Posts', $result);
-         self::assertInstanceOf(DbModel::class, $result['Post']);
-         self::assertNotEmpty($result['Post']->many2many);
-         self::assertArrayHasKey('tags', $result['Post']->many2many);
-         self::assertArrayHasKey('photos', $result['Post']->many2many);
-         self::assertArrayHasKey('photos2posts', $result['Post']->relations);
-         self::assertArrayNotHasKey('photos2posts', $result['Post']->many2many);
-         self::assertFalse($result['Post']->many2many['tags']->hasViaModel);
-         self::assertFalse($result['Tag']->many2many['posts']->hasViaModel);
-         self::assertTrue($result['Post']->many2many['photos']->hasViaModel);
-         self::assertTrue($result['Photo']->many2many['posts']->hasViaModel);
-     }
+    public function testFindJunctionSchemas()
+    {
+        $schemaFile = Yii::getAlias("@specs/many2many.yaml");
+        $openApi = Reader::readFromYamlFile($schemaFile, OpenApi::class, false);
+        $result = (new SchemaToDatabase())->findJunctionSchemas($openApi);
+        VarDumper::dump($result->indexByJunctionRef());
+        VarDumper::dump($result->indexByJunctionSchema());
+        self::assertInstanceOf(JunctionSchemas::class, $result);
+        self::assertEqualsCanonicalizing(
+            ['junk_Photos2Posts', 'junk_PostsGallery', 'junk_PostsAttaches'],
+            array_keys($result->indexByJunctionSchema())
+        );
+        self::assertEqualsCanonicalizing(
+            ['Post', 'Photo'],
+            array_keys($result->indexByClassSchema())
+        );
+        self::assertEquals('junk_PostAttaches', $result->addPrefix('PostAttaches'));
+        self::assertEquals('PostAttaches', $result->trimPrefix('junk_PostAttaches'));
+        self::assertTrue($result->isJunctionSchema('PostsAttaches'));
+        self::assertTrue($result->isJunctionSchema('junk_PostsAttaches'));
+        self::assertTrue($result->isManyToManyProperty('Post', 'image'));
+        self::assertTrue($result->isManyToManyProperty('Post', 'photo'));
+        self::assertTrue($result->isManyToManyProperty('Photo', 'article'));
+        self::assertTrue($result->isManyToManyProperty('Photo', 'post'));
+        self::assertTrue($result->isJunctionProperty('junk_PostsGallery', 'image'));
+        self::assertTrue($result->isJunctionProperty('PostsGallery', 'article'));
+        self::assertTrue($result->isJunctionProperty('junk_Photos2Posts', 'photo'));
+        self::assertTrue($result->isJunctionProperty('junk_Photos2Posts', 'post'));
+        self::assertTrue($result->isJunctionProperty('Photos2Posts', 'post'));
+        self::assertTrue($result->isJunctionRef('Photo', 'posts_gallery'));
+        self::assertTrue($result->isJunctionRef('Photo', 'posts_attaches'));
+        self::assertTrue($result->isJunctionRef('Post', 'posts_gallery'));
+    }
+
+    public function testGenerateModels()
+    {
+        $schemaFile = Yii::getAlias("@specs/many2many.yaml");
+        $openApi = Reader::readFromYamlFile($schemaFile, OpenApi::class, false);
+        $converter = new SchemaToDatabase([]);
+        $result = $converter->generateModels($openApi);
+        self::assertNotEmpty($result);
+        self::assertArrayHasKey('Post', $result);
+        self::assertArrayHasKey('Tag', $result);
+        self::assertArrayHasKey('Photo', $result);
+        self::assertArrayHasKey('Photos2Posts', $result);
+        self::assertArrayHasKey('PostsGallery', $result);
+        self::assertArrayHasKey('PostsAttaches', $result);
+        self::assertInstanceOf(DbModel::class, $result['Photo']);
+        self::assertInstanceOf(DbModel::class, $result['Post']);
+
+        self::assertNotEmpty($result['Post']->many2many);
+        self::assertArrayHasKey('tags', $result['Post']->many2many);
+        self::assertArrayHasKey('photos', $result['Post']->many2many);
+        self::assertArrayHasKey('images', $result['Post']->many2many);
+        self::assertArrayHasKey('attaches', $result['Post']->many2many);
+        self::assertArrayHasKey('posts_photos', $result['Post']->relations);
+        self::assertArrayNotHasKey('posts_photos', $result['Post']->many2many);
+
+        self::assertNotEmpty($result['Photo']->many2many);
+        self::assertArrayNotHasKey('tags', $result['Photo']->many2many);
+        self::assertArrayHasKey('posts', $result['Photo']->many2many);
+        self::assertArrayHasKey('articles', $result['Photo']->many2many);
+        self::assertArrayHasKey('targets', $result['Photo']->many2many);
+        self::assertArrayHasKey('photos_posts', $result['Photo']->relations);
+        self::assertArrayNotHasKey('posts_photos', $result['Post']->many2many);
+
+        self::assertNotEmpty($result['PostsGallery']->attributes['image']);
+        self::assertNotEmpty($result['PostsGallery']->attributes['article']);
+        self::assertArrayHasKey('image', $result['PostsGallery']->relations);
+        self::assertArrayHasKey('article', $result['PostsGallery']->relations);
+
+        self::assertNotEmpty($result['PostsAttaches']->attributes['target']);
+        self::assertNotEmpty($result['PostsAttaches']->attributes['attach']);
+        self::assertArrayHasKey('target', $result['PostsAttaches']->relations);
+        self::assertArrayHasKey('attach', $result['PostsAttaches']->relations);
+
+        self::assertNotEmpty($result['Photos2Posts']->attributes['post']);
+        self::assertNotEmpty($result['Photos2Posts']->attributes['photo']);
+        self::assertArrayHasKey('post', $result['Photos2Posts']->relations);
+        self::assertArrayHasKey('photo', $result['Photos2Posts']->relations);
+
+        self::assertFalse($result['Post']->many2many['tags']->hasViaModel);
+        self::assertFalse($result['Tag']->many2many['posts']->hasViaModel);
+        self::assertTrue($result['Post']->many2many['photos']->hasViaModel);
+        self::assertTrue($result['Photo']->many2many['posts']->hasViaModel);
+    }
 }


### PR DESCRIPTION
fix faker: allow setting unsafe attributes

Remake many-to-many relations generation.
 -   Add the ability to have multiple relations between same models, that was impossible previously.
 -   Also allow making more flexible naming for junction models, tables and relations
 -   Fix phpdoc for relations

Fix action naming for non-crud actions