### PR TITLE
add namespaces for included transformers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 	},
 	"require": {
 		"php": ">=7.1.0",
-		"cebe/php-openapi": "dev-wip-reference-cache as 1.5",
+		"cebe/php-openapi": "^1.5",
 		"yiisoft/yii2": "~2.0.15",
 		"yiisoft/yii2-gii": "~2.0.0 | ~2.1.0| ~2.2.0",
 		"fzaninotto/faker": "^1.8",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 	},
 	"require": {
 		"php": ">=7.1.0",
-		"cebe/php-openapi": "^1.5",
+        "cebe/php-openapi": "^1.5.0",
 		"yiisoft/yii2": "~2.0.15",
 		"yiisoft/yii2-gii": "~2.0.0 | ~2.1.0| ~2.2.0",
 		"fzaninotto/faker": "^1.8",

--- a/src/generator/ApiGenerator.php
+++ b/src/generator/ApiGenerator.php
@@ -479,6 +479,8 @@ PHP;
                     Yii::getAlias("{$dirPath}/{$transformer->name}.php"),
                     $this->render('transformer.php', [
                         'namespace' => $this->transformerNamespace . ($this->extendableTransformers ? '\\base' : ''),
+                        'mainNamespace' => $this->transformerNamespace,
+                        'extendable' => $this->extendableTransformers,
                         'transformer' => $transformer
                     ])
                 );

--- a/src/generator/default/transformer.php
+++ b/src/generator/default/transformer.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * @var string $namespace
+ * @var string $namespace (current namespace, maby be base, if transformers are extendable)
+ * @var string $mainNamespace  (main namespace)
+ * @var bool $extendable
  * @var \cebe\yii2openapi\lib\items\Transformer $transformer
 */
 use yii\helpers\Inflector;
@@ -12,6 +14,14 @@ namespace <?= $namespace ?>;
 
 use League\Fractal\TransformerAbstract;
 use <?=$transformer->modelFQN?>;
+<?php if ($extendable === true && $transformer->shouldIncludeRelations()):?>
+<?php foreach ($transformer->relations as $relation):?>
+use <?=$mainNamespace?>\<?=Inflector::singularize($relation->getClassName())?>Transformer;
+<?php endforeach;?>
+<?php foreach ($transformer->many2Many as $relation):?>
+use <?=$mainNamespace?>\<?=Inflector::singularize($relation->getRelatedClassName())?>Transformer;
+<?php endforeach;?>
+<?php endif;?>
 
 class <?=$transformer->name?> extends TransformerAbstract
 {

--- a/tests/specs/blog_jsonapi/transformers/base/CategoryTransformer.php
+++ b/tests/specs/blog_jsonapi/transformers/base/CategoryTransformer.php
@@ -3,6 +3,7 @@ namespace app\transformers\base;
 
 use League\Fractal\TransformerAbstract;
 use app\models\Category;
+use app\transformers\PostTransformer;
 
 class CategoryTransformer extends TransformerAbstract
 {

--- a/tests/specs/blog_jsonapi/transformers/base/CommentTransformer.php
+++ b/tests/specs/blog_jsonapi/transformers/base/CommentTransformer.php
@@ -3,6 +3,8 @@ namespace app\transformers\base;
 
 use League\Fractal\TransformerAbstract;
 use app\models\Comment;
+use app\transformers\PostTransformer;
+use app\transformers\UserTransformer;
 
 class CommentTransformer extends TransformerAbstract
 {

--- a/tests/specs/blog_jsonapi/transformers/base/PostTransformer.php
+++ b/tests/specs/blog_jsonapi/transformers/base/PostTransformer.php
@@ -3,6 +3,10 @@ namespace app\transformers\base;
 
 use League\Fractal\TransformerAbstract;
 use app\models\Post;
+use app\transformers\CategoryTransformer;
+use app\transformers\UserTransformer;
+use app\transformers\CommentTransformer;
+use app\transformers\PostTagTransformer;
 
 class PostTransformer extends TransformerAbstract
 {

--- a/tests/specs/blog_jsonapi/transformers/base/TagTransformer.php
+++ b/tests/specs/blog_jsonapi/transformers/base/TagTransformer.php
@@ -3,6 +3,7 @@ namespace app\transformers\base;
 
 use League\Fractal\TransformerAbstract;
 use app\models\Tag;
+use app\transformers\PostTagTransformer;
 
 class TagTransformer extends TransformerAbstract
 {


### PR DESCRIPTION
Otherwise, transformers from the "base" folder referred to another base* transformers instead of common