### PR TITLE
fix #69 #46

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Explicitly specify primary key name for table, if it is different from "id"
 ### `x-db-type`
 
 Explicitly specify the database type for a column. (MUST contains only db type! (json, jsonb, uuid, varchar etc))
+If x-db-type sets as false, property will be processed as virtual;
+It will be added in model as public property, but skipped for migrations generation
 
 ### `x-indexes`
 Specify table indexes

--- a/src/lib/FakerStubResolver.php
+++ b/src/lib/FakerStubResolver.php
@@ -42,6 +42,9 @@ class FakerStubResolver
         if (isset($this->property->{CustomSpecAttr::FAKER})) {
             return $this->property->{CustomSpecAttr::FAKER};
         }
+        if ($this->attribute->isReadOnly() && $this->attribute->isVirtual()) {
+            return null;
+        }
         $limits = $this->attribute->limits;
         switch ($this->attribute->phpType) {
             case 'bool':

--- a/src/lib/SchemaTypeResolver.php
+++ b/src/lib/SchemaTypeResolver.php
@@ -49,7 +49,7 @@ class SchemaTypeResolver
 
     public static function schemaToDbType(Schema $property, bool $isPrimary = false):string
     {
-        if (isset($property->{CustomSpecAttr::DB_TYPE})) {
+        if (isset($property->{CustomSpecAttr::DB_TYPE}) && $property->{CustomSpecAttr::DB_TYPE} !== false) {
             $customDbType = strtolower($property->{CustomSpecAttr::DB_TYPE});
             if ($customDbType === 'varchar') {
                 return YiiDbSchema::TYPE_STRING;
@@ -94,6 +94,9 @@ class SchemaTypeResolver
                     return YiiDbSchema::TYPE_STRING;
                 }
                 return YiiDbSchema::TYPE_TEXT;
+            case 'object': {
+                return YiiDbSchema::TYPE_JSON;
+            }
 //            case 'array':
 //                Need schema example for this case if it possible
 //                return $this->typeForArray();

--- a/src/lib/items/Attribute.php
+++ b/src/lib/items/Attribute.php
@@ -93,6 +93,11 @@ class Attribute extends BaseObject
      **/
     public $fakerStub;
 
+    /**
+     * @var bool
+     **/
+    public $isVirtual = false;
+
     public function __construct(string $propertyName, array $config = [])
     {
         $this->propertyName = $propertyName;
@@ -172,6 +177,12 @@ class Attribute extends BaseObject
         return $this;
     }
 
+    public function setIsVirtual(): Attribute
+    {
+        $this->isVirtual = true;
+        return $this;
+    }
+
 
     public function asReference(string $relatedClass):Attribute
     {
@@ -192,6 +203,11 @@ class Attribute extends BaseObject
     public function isRequired():bool
     {
         return $this->required;
+    }
+
+    public function isVirtual():bool
+    {
+        return $this->isVirtual;
     }
 
     public function camelName():string

--- a/tests/specs/petstore_jsonapi.php
+++ b/tests/specs/petstore_jsonapi.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    'openApiPath' => '@specs/petstore_arrayref.yaml',
+    'openApiPath' => '@specs/petstore_jsonapi.yaml',
     'generateUrls' => true,
     'generateModels' => true,
     'excludeModels' => [

--- a/tests/specs/petstore_jsonapi.yaml
+++ b/tests/specs/petstore_jsonapi.yaml
@@ -1,0 +1,154 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: A paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /pets/{petId}:
+    parameters:
+      -   name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      responses:
+        '200':
+          $ref: "#/components/responses/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    patch:
+      summary: update a specific pet
+      operationId: updatePetById
+      tags:
+        - pets
+      responses:
+        '200':
+          description: The updated pet
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+    delete:
+      summary: delete a specific pet
+      operationId: deletePetById
+      tags:
+        - pets
+      responses:
+        '204':
+          description: successfully deleted pet
+components:
+  schemas:
+    Pet:
+      description: A Pet
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+          readOnly: True
+        name:
+          type: string
+        tag:
+          type: string
+          x-faker: "$faker->randomElement(['one', 'two', 'three', 'four'])"
+        guests_count:
+          type: integer
+          readOnly: true
+          x-db-type: false
+          description: 'Internal relation counter example'
+        petCode:
+          type: string
+          readOnly: false
+          maxLength: 50
+          x-db-type: false
+          description: 'Virtual attribute example'
+        duplicates:
+          type: array
+          readOnly: true
+          items:
+            $ref: "#/components/schemas/Pet/properties/tag"
+
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+  responses:
+    Pets:
+      description: Expected response to a valid request
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/Pet"

--- a/tests/specs/petstore_jsonapi/models/PetFaker.php
+++ b/tests/specs/petstore_jsonapi/models/PetFaker.php
@@ -32,6 +32,7 @@ class PetFaker extends BaseModelFaker
         //$model->id = $uniqueFaker->numberBetween(0, 2147483647);
         $model->name = $faker->sentence;
         $model->tag = $faker->randomElement(['one', 'two', 'three', 'four']);
+        $model->petCode = substr($faker->text(50), 0, 50);
         if (!is_callable($attributes)) {
             $model->setAttributes($attributes, false);
         } else {

--- a/tests/specs/petstore_jsonapi/models/base/Pet.php
+++ b/tests/specs/petstore_jsonapi/models/base/Pet.php
@@ -13,18 +13,44 @@ namespace app\models\base;
  */
 abstract class Pet extends \yii\db\ActiveRecord
 {
+    protected $virtualAttributes = ['guests_count', 'petCode'];
+
+    /**
+     * @var int
+    */
+    public $guests_count;
+
+    /**
+     * @var string
+    */
+    public $petCode;
+
     public static function tableName()
     {
         return '{{%pets}}';
     }
 
+    public function attributes()
+    {
+        return array_merge(parent::attributes(), $this->virtualAttributes);
+    }
+
+    public function afterFind()
+    {
+        parent::afterFind();
+        foreach ($this->virtualAttributes as $attr) {
+            $this->$attr = $this->getAttribute($attr);
+        }
+    }
+
     public function rules()
     {
         return [
-            'trim' => [['name', 'tag'], 'trim'],
+            'trim' => [['name', 'tag', 'petCode'], 'trim'],
             'required' => [['name'], 'required'],
             'name_string' => [['name'], 'string'],
             'tag_string' => [['tag'], 'string'],
+            'petCode_string' => [['petCode'], 'string', 'max' => 50],
         ];
     }
 


### PR DESCRIPTION
Allow to define virtual attributes with "x-db-type: false", that will be skipped for migration generation, but available in model and presents for response