### PR TITLE
Fix-xDbType

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,52 @@ $this->update('{{%company}}', ['name' => 'No name']);
 $this->alterColumn('{{%company}}', 'name', $this->string(128)->notNull());
 ```
 
+### Handling of `NOT NULL` constraints (#required, #nullable)
+
+e.g. attribute = 'alpha'.
+
+1) If you define attribute neither "required" nor via "nullable", then it is by default:
+   ALLOW 'NOT NULL'
+ ```yaml
+  test_table:
+    required:
+    properties:
+      alpha:
+        type: string
+```
+
+2) If you define attribute by "required", then it is:
+   FORBIDDEN 'NOT NULL'
+ ```yaml
+  test_table:
+    required:
+     - alpha
+    properties:
+      alpha:
+        type: string
+```
+
+3) If you define attribute via "nullable", then it has the highest priority.
+   ALLOW 'NOT NULL'
+ ```yaml
+  test_table:
+    required:
+      - alpha
+    properties:
+      alpha:
+        type: string
+        nullable: true
+```
+
+FORBIDDEN 'NOT NULL'
+ ```yaml
+  test_table:
+    required:
+    properties:
+      alpha:
+        type: string
+        nullable: false
+```
 
 ## Screenshots
 

--- a/README.md
+++ b/README.md
@@ -309,6 +309,37 @@ It work on MariaDb.
           - three
 ```
 
+### Handling of `numeric` (#numeric, #MariaDb)
+precision-default = 10
+scale-default = 2
+
+- You can define attribute like "numeric(precision,scale)":
+ ```yaml
+  test_table:
+    properties:
+      my_property:
+        x-db-type: decimal(12,4)
+```
+DB-Result = decimal(12,4)
+
+- You can define attribute like "numeric(precision)" with default scale-default = 2:
+ ```yaml
+  test_table:
+    properties:
+      my_property:
+        x-db-type: decimal(12)
+```
+DB-Result = decimal(12,2)
+
+- You can define attribute like "numeric" with precision-default = 10 and scale-default = 2:
+ ```yaml
+  test_table:
+    properties:
+      my_property:
+        x-db-type: decimal
+```
+DB-Result = decimal(10,2)
+
 ## Screenshots
 
 Gii Generator Form:

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ $this->alterColumn('{{%company}}', 'name', $this->string(128)->notNull());
 
 ### Handling of `NOT NULL` constraints (#required, #nullable)
 
-e.g. attribute = 'alpha'.
+e.g. attribute = 'my_property'.
 
 1) If you define attribute neither "required" nor via "nullable", then it is by default:
    ALLOW 'NOT NULL'
@@ -258,7 +258,7 @@ e.g. attribute = 'alpha'.
   test_table:
     required:
     properties:
-      alpha:
+      my_property:
         type: string
 ```
 
@@ -267,9 +267,9 @@ e.g. attribute = 'alpha'.
  ```yaml
   test_table:
     required:
-     - alpha
+     - my_property
     properties:
-      alpha:
+      my_property:
         type: string
 ```
 
@@ -278,9 +278,9 @@ e.g. attribute = 'alpha'.
  ```yaml
   test_table:
     required:
-      - alpha
+      - my_property
     properties:
-      alpha:
+      my_property:
         type: string
         nullable: true
 ```
@@ -290,9 +290,22 @@ FORBIDDEN 'NOT NULL'
   test_table:
     required:
     properties:
-      alpha:
+      my_property:
         type: string
         nullable: false
+```
+
+### Handling of `enum` (#enum, #MariaDb)
+It work on MariaDb.
+
+ ```yaml
+  test_table:
+    properties:
+      my_property:
+        enum:
+          - one
+          - two
+          - three
 ```
 
 ## Screenshots

--- a/src/lib/AttributeResolver.php
+++ b/src/lib/AttributeResolver.php
@@ -204,6 +204,7 @@ class AttributeResolver
                   ->setReadOnly($property->isReadonly())
                   ->setDefault($property->guessDefault())
                   ->setXDbType($property->getAttr('x-db-type', null))
+                  ->setNullable($property->getProperty()->getSerializableData()->nullable ?? null)
                   ->setIsPrimary($property->isPrimaryKey());
         if ($property->isReference()) {
             if ($property->isVirtual()) {

--- a/src/lib/AttributeResolver.php
+++ b/src/lib/AttributeResolver.php
@@ -203,6 +203,7 @@ class AttributeResolver
                   ->setDescription($property->getAttr('description', ''))
                   ->setReadOnly($property->isReadonly())
                   ->setDefault($property->guessDefault())
+                  ->setXDbType($property->getAttr('x-db-type', null))
                   ->setIsPrimary($property->isPrimaryKey());
         if ($property->isReference()) {
             if ($property->isVirtual()) {

--- a/src/lib/items/Attribute.php
+++ b/src/lib/items/Attribute.php
@@ -47,6 +47,11 @@ class Attribute extends BaseObject
     public $dbType = 'string';
 
     /**
+     * Custom db type
+     */
+    public $xDbType;
+
+    /**
      * @var string
      */
     public $description = '';
@@ -115,6 +120,17 @@ class Attribute extends BaseObject
     {
         $this->dbType = $dbType;
         return $this;
+    }
+
+    public function setXDbType($xDbType):Attribute
+    {
+        $this->xDbType = $xDbType;
+        return $this;
+    }
+
+    public function getXDbType($xDbType)
+    {
+        return $this->xDbType;
     }
 
     public function setDescription(string $description):Attribute
@@ -270,6 +286,13 @@ class Attribute extends BaseObject
 
     private function dbTypeAbstract(string $type):string
     {
+        /**
+         * Custom db type
+         */
+        if ($this->xDbType){
+            return $this->xDbType;
+        }
+
         if (stripos($type, 'int') === 0) {
             return 'integer';
         }

--- a/src/lib/items/Attribute.php
+++ b/src/lib/items/Attribute.php
@@ -48,8 +48,15 @@ class Attribute extends BaseObject
 
     /**
      * Custom db type
+     * string | null
      */
     public $xDbType;
+
+    /**
+     * nullable
+     * bool | null
+     */
+    public $nullable;
 
     /**
      * @var string
@@ -128,9 +135,10 @@ class Attribute extends BaseObject
         return $this;
     }
 
-    public function getXDbType($xDbType)
+    public function setNullable($nullable):Attribute
     {
-        return $this->xDbType;
+        $this->nullable = $nullable;
+        return $this;
     }
 
     public function setDescription(string $description):Attribute
@@ -263,7 +271,7 @@ class Attribute extends BaseObject
             'phpType'=>$this->phpType,
             'dbType' => strtolower($this->dbType),
             'type' => $this->dbTypeAbstract($this->dbType),
-            'allowNull' => !$this->isRequired(),
+            'allowNull' => $this->allowNull(),
             'size' => $this->size > 0 ? $this->size : null,
         ]);
         $column->isPrimaryKey = $this->primary;
@@ -312,5 +320,13 @@ class Attribute extends BaseObject
             return 'timestamp';
         }
         return $type;
+    }
+
+    private function allowNull()
+    {
+        if (is_bool($this->nullable)){
+            return $this->nullable;
+        }
+        return !$this->isRequired();
     }
 }

--- a/src/lib/items/DbModel.php
+++ b/src/lib/items/DbModel.php
@@ -139,8 +139,7 @@ class DbModel extends BaseObject
         return array_filter(
             $this->attributes,
             static function (Attribute $attribute) {
-                return !$attribute->isVirtual && StringHelper::startsWith($attribute->dbType, 'enum')
-                    && !empty($attribute->enumValues);
+                return !$attribute->isVirtual && !empty($attribute->enumValues);
             }
         );
     }

--- a/src/lib/migrations/BaseMigrationBuilder.php
+++ b/src/lib/migrations/BaseMigrationBuilder.php
@@ -205,6 +205,10 @@ abstract class BaseMigrationBuilder
                 $current->type = 'enum';
                 $current->dbType = 'enum';
             }
+            if (!empty($desired->enumValues)) {
+                $desired->type = 'enum';
+                $desired->dbType = 'enum';
+            }
             $changedAttributes = $this->compareColumns($current, $desired);
             if (empty($changedAttributes)) {
                 continue;

--- a/src/lib/migrations/MysqlMigrationBuilder.php
+++ b/src/lib/migrations/MysqlMigrationBuilder.php
@@ -66,7 +66,7 @@ final class MysqlMigrationBuilder extends BaseMigrationBuilder
 
     protected function createEnumMigrations():void
     {
-        // Postgres only case
+        // execute via default
     }
 
     protected function isDbDefaultSize(ColumnSchema $current):bool

--- a/src/lib/migrations/MysqlMigrationBuilder.php
+++ b/src/lib/migrations/MysqlMigrationBuilder.php
@@ -7,6 +7,7 @@
 
 namespace cebe\yii2openapi\lib\migrations;
 
+use cebe\yii2openapi\lib\ColumnToCode;
 use cebe\yii2openapi\lib\items\DbIndex;
 use yii\base\NotSupportedException;
 use yii\db\ColumnSchema;
@@ -56,6 +57,19 @@ final class MysqlMigrationBuilder extends BaseMigrationBuilder
         if ($current->type === $desired->type && !$desired->size && $this->isDbDefaultSize($current)) {
             $desired->size = $current->size;
         }
+        
+        if ($decimalAttributes = ColumnToCode::isDecimalByDbType($desired->dbType)){
+            $desired->precision = $decimalAttributes['precision'];
+            $desired->scale = $decimalAttributes['scale'];
+            $desired->type = 'decimal';
+            $desired->size = $decimalAttributes['precision'];
+            foreach (['precision', 'scale', 'dbType'] as $decimalAttr) {
+                if ($current->$decimalAttr !== $desired->$decimalAttr) {
+                    $changedAttributes[] = $decimalAttr;
+                }
+            }
+        }
+        
         foreach (['type', 'size', 'allowNull', 'defaultValue', 'enumValues'] as $attr) {
             if ($current->$attr !== $desired->$attr) {
                 $changedAttributes[] = $attr;


### PR DESCRIPTION
**x-db-type** will no longer be reformatted from now on.
**x-db-type** is now the final entry in db.

nullalble property is handled correctly.

usecase
```
created_at:
  readOnly: true
  type: string
  format: datetime
  x-db-type: datetime
  nullable: false
```


fixes #100 
fixes #99 