### PR TITLE
Actually run tests on different PHP versions

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,0 +1,1 @@
+PHP_VERSION=7.4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,10 +46,10 @@ jobs:
         run: docker-compose exec php php -v && make installdocker
 
       - name: Migrate
-        run: make migrate
+        run: make UID=0 migrate
 
       - name: Check style
         run: make check-style-from-host
 
       - name: Run tests
-        run: make testdocker
+        run: make UID=0 testdocker

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,9 @@
 name: yii2-openapi
 on:
   push:
-    branches: [ master, wip]
+    branches: [ master ]
   pull_request:
-    branches: [ master, wip ]
+    branches: [ master ]
     paths-ignore:
       - 'docs/**'
       - '*.md'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
 
     # TODO use cache
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set PHP Version
         run: echo "PHP_VERSION=${{ matrix.php-versions }}" > .env
@@ -49,6 +49,7 @@ jobs:
         run: make UID=0 migrate
 
       - name: Check style
+        if: "!contains(matrix.php-versions, '8.')"
         run: make check-style-from-host
 
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       DB_PASSWORD: dbpass
       DB_CHARSET: utf8
     strategy:
-#      fail-fast: true
+      fail-fast: false
       matrix:
         php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,11 +20,14 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php-versions: ['7.1', '7.2', '7.3', '7.4']
+        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
 
     # TODO use cache
     steps:
       - uses: actions/checkout@v2
+
+      - name: Set PHP Version
+        run: echo "PHP_VERSION=${{ matrix.php-versions }}" > .env
 
       # Run every tests inside Docker container
       - name: Docker Compose Setup
@@ -40,7 +43,7 @@ jobs:
         run: make up
 
       - name: Install Docker and composer dependencies
-        run: make installdocker
+        run: docker-compose exec php php -v && make installdocker
 
       - name: Migrate
         run: make migrate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,9 @@ jobs:
       DB_PASSWORD: dbpass
       DB_CHARSET: utf8
     strategy:
-      fail-fast: true
+#      fail-fast: true
       matrix:
-        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
 
     # TODO use cache
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /composer.lock
 /phpunit.xml
 /.php_cs.cache
+/.env

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /phpunit.xml
 /.php_cs.cache
 /.env
+/.phpunit.result.cache

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,88 @@
+Yii2-openapi Contribution Docs
+==============================
+
+To contribute or play around, steps to set up this project up locally are:
+
+```bash
+# in your CLI
+git clone https://github.com/cebe/yii2-openapi.git
+cd yii2-openapi
+make clean_all
+make up
+make installdocker
+make migrate
+
+# to check everything is setup up correctly ensure all tests passes
+make cli
+./vendor/bin/phpunit
+
+# create new branch from master and Happy contributing!
+```
+
+These commands are available to develop and check the tests. It is available inside the Docker container. To enter into bash shell of container, run `make cli` .
+
+```bash
+cd tests
+./yii migrate-mysql/up
+./yii migrate-mysql/down 4
+
+./yii migrate-maria/up
+./yii migrate-maria/down 4
+
+./yii migrate-pgsql/up
+./yii migrate-pgsql/down 4
+```
+
+To apply multiple migration with one command:
+
+```bash
+./yii migrate-mysql/up --interactive=0 && \
+./yii migrate-mysql/down --interactive=0 4 && \
+./yii migrate-maria/up --interactive=0 && \
+./yii migrate-maria/down --interactive=0 4 && \
+./yii migrate-pgsql/up --interactive=0 && \
+./yii migrate-pgsql/down --interactive=0 4
+```
+
+
+Switching PHP versions
+----------------------
+
+You can switch the PHP version of the docker runtime by changing the `PHP_VERSION` environment variable in the `.env` file.
+
+If you have no `.env` file yet, create it by copying `.env.dist` to `.env`.
+
+After changing the PHP Version you need to run `make down up` to start the new container with new version.
+
+Example:
+
+```
+$ echo "PHP_VERSION=7.4" > .env
+$ make down up cli
+Stopping yii2-openapi_php_1      ... done
+Stopping yii2-openapi_maria_1    ... done
+Stopping yii2-openapi_postgres_1 ... done
+Stopping yii2-openapi_mysql_1    ... done
+Removing yii2-openapi_php_1      ... done
+Removing yii2-openapi_maria_1    ... done
+Removing yii2-openapi_postgres_1 ... done
+Removing yii2-openapi_mysql_1    ... done
+Removing network yii2-openapi_default
+Creating network "yii2-openapi_default" with driver "bridge"
+Creating yii2-openapi_maria_1    ... done
+Creating yii2-openapi_mysql_1    ... done
+Creating yii2-openapi_postgres_1 ... done
+Creating yii2-openapi_php_1      ... done
+docker-compose exec php bash
+
+root@f9928598f841:/app# php -v
+
+PHP 7.4.27 (cli) (built: Jan 26 2022 18:08:44) ( NTS )
+Copyright (c) The PHP Group
+Zend Engine v3.4.0, Copyright (c) Zend Technologies
+with Zend OPcache v7.4.27, Copyright (c), by Zend Technologies
+with Xdebug v2.9.6, Copyright (c) 2002-2020, by Derick Rethans
+```
+
+
+

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ PHPARGS=-dmemory_limit=64M
 #PHPARGS=-dmemory_limit=64M -dzend_extension=xdebug.so -dxdebug.remote_enable=1 -dxdebug.remote_host=127.0.0.1 -dxdebug.remote_autostart=1
 #PHPARGS=-dmemory_limit=64M -dxdebug.remote_enable=1
 
+UID=$(shell id -u)
+
 all:
 
 check-style:
@@ -42,18 +44,18 @@ up:
 	docker-compose exec -T mysql timeout 60s sh -c "while ! (mysql --execute \"ALTER USER 'dbuser'@'%' IDENTIFIED WITH mysql_native_password BY 'dbpass';\" > /dev/null 2>&1); do echo -n '.'; sleep 0.1 ; done; echo 'ok'" || (docker-compose ps; docker-compose logs; exit 1)
 
 cli:
-	docker-compose exec --user=$$(id -u) php bash
+	docker-compose exec --user=$(UID) php bash
 
 migrate:
-	docker-compose run --user=$$(id -u) --rm php sh -c 'mkdir -p "tests/tmp/app"'
-	docker-compose run --user=$$(id -u) --rm php sh -c 'mkdir -p "tests/tmp/docker_app"'
-	docker-compose run --user=$$(id -u) --rm php sh -c 'cd /app/tests && ./yii migrate  --interactive=0'
+	docker-compose run --user=$(UID) --rm php sh -c 'mkdir -p "tests/tmp/app"'
+	docker-compose run --user=$(UID) --rm php sh -c 'mkdir -p "tests/tmp/docker_app"'
+	docker-compose run --user=$(UID) --rm php sh -c 'cd /app/tests && ./yii migrate  --interactive=0'
 
 installdocker:
-	docker-compose run --user=$$(id -u) --rm php composer install && chmod +x tests/yii
+	docker-compose run --user=$(UID) --rm php composer install && chmod +x tests/yii
 
 testdocker:
-	docker-compose run --user=$$(id -u) --rm php sh -c 'vendor/bin/phpunit'
+	docker-compose run --user=$(UID) --rm php sh -c 'vendor/bin/phpunit'
 
 efs: clean_all up migrate # Everything From Scratch
 

--- a/Makefile
+++ b/Makefile
@@ -42,18 +42,18 @@ up:
 	docker-compose exec -T mysql timeout 60s sh -c "while ! (mysql --execute \"ALTER USER 'dbuser'@'%' IDENTIFIED WITH mysql_native_password BY 'dbpass';\" > /dev/null 2>&1); do echo -n '.'; sleep 0.1 ; done; echo 'ok'" || (docker-compose ps; docker-compose logs; exit 1)
 
 cli:
-	docker-compose exec php bash
+	docker-compose exec --user=$$(id -u) php bash
 
 migrate:
-	docker-compose run --rm php sh -c 'mkdir -p "tests/tmp/app"'
-	docker-compose run --rm php sh -c 'mkdir -p "tests/tmp/docker_app"'
-	docker-compose run --rm php sh -c 'cd /app/tests && ./yii migrate  --interactive=0'
+	docker-compose run --user=$$(id -u) --rm php sh -c 'mkdir -p "tests/tmp/app"'
+	docker-compose run --user=$$(id -u) --rm php sh -c 'mkdir -p "tests/tmp/docker_app"'
+	docker-compose run --user=$$(id -u) --rm php sh -c 'cd /app/tests && ./yii migrate  --interactive=0'
 
 installdocker:
-	docker-compose run --rm php composer install && chmod +x tests/yii
+	docker-compose run --user=$$(id -u) --rm php composer install && chmod +x tests/yii
 
 testdocker:
-	docker-compose run --rm php sh -c 'vendor/bin/phpunit'
+	docker-compose run --user=$$(id -u) --rm php sh -c 'vendor/bin/phpunit'
 
 efs: clean_all up migrate # Everything From Scratch
 

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ clean:
 	sudo rm -rf tests/tmp/app/*
 	sudo rm -rf tests/tmp/docker_app/*
 
+down:
+	docker-compose down --remove-orphans
+
 up:
 	docker-compose up -d
 	echo "Waiting for mariadb to start up..."
@@ -54,7 +57,7 @@ testdocker:
 
 efs: clean_all up migrate # Everything From Scratch
 
-.PHONY: all check-style fix-style install test clean clean_all up cli installdocker migrate testdocker efs
+.PHONY: all check-style fix-style install test clean clean_all up down cli installdocker migrate testdocker efs
 
 
 # Docs:

--- a/README.md
+++ b/README.md
@@ -472,48 +472,7 @@ Generated files:
 
 # Development
 
-To contribute or play around, steps to set up this project locally are:
-
-```bash
-# in your CLI
-git clone https://github.com/cebe/yii2-openapi.git
-cd yii2-openapi
-make clean_all
-make up
-make cli
-composer install
-make migrate
-
-# to check everything is setup up correctly ensure all tests passes
-./vendor/bin/phpunit
-
-# create new branch from master and Happy contributing!
-```
-
-These commands are available to develop and check the tests. It is available inside the Docker container. To enter into bash shell of container, run `make cli` .
-
-```bash
-cd tests
-./yii migrate-mysql/up
-./yii migrate-mysql/down 4
-
-./yii migrate-maria/up
-./yii migrate-maria/down 4
-
-./yii migrate-pgsql/up
-./yii migrate-pgsql/down 4
-```
-
-To apply multiple migration with one command:
-
-```bash
-./yii migrate-mysql/up --interactive=0 && \
-./yii migrate-mysql/down --interactive=0 4 && \
-./yii migrate-maria/up --interactive=0 && \
-./yii migrate-maria/down --interactive=0 4 && \
-./yii migrate-pgsql/up --interactive=0 && \
-./yii migrate-pgsql/down --interactive=0 4
-```
+To contribute or play around, steps to set up this project up locally are in [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 
 # Support

--- a/composer.json
+++ b/composer.json
@@ -44,9 +44,6 @@
 		}
 	},
 	"config": {
-		"platform": {
-			"php": "7.1.3"
-		},
 		"allow-plugins": {
 			"yiisoft/yii2-composer": true
 		}

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
 	"require-dev": {
 		"cebe/indent": "*",
 		"friendsofphp/php-cs-fixer": "~2.16",
-		"phpunit/phpunit": "^6.5|^8.0|^9.0",
+		"phpunit/phpunit": "^8.0",
 		"yiisoft/yii2-gii": ">=2.1.0"
 	},
 	"autoload": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"source": "https://github.com/cebe/yii2-openapi"
 	},
 	"require": {
-		"php": ">=7.1.0",
+		"php": ">=7.2.0",
 		"cebe/php-openapi": "^1.5.0",
 		"yiisoft/yii2": "~2.0.15",
 		"yiisoft/yii2-gii": "~2.0.0 | ~2.1.0 | ~2.2.0| ~2.3.0",

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
 		"cebe/indent": "*",
 		"friendsofphp/php-cs-fixer": "~2.16",
 		"phpunit/phpunit": "^8.0",
+		"symfony/polyfill-php80": "^1.16",
 		"yiisoft/yii2-gii": ">=2.1.0"
 	},
 	"autoload": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 		"cebe/php-openapi": "^1.5.0",
 		"yiisoft/yii2": "~2.0.15",
 		"yiisoft/yii2-gii": "~2.0.0 | ~2.1.0 | ~2.2.0| ~2.3.0",
-		"laminas/laminas-code": "^3.4",
+		"laminas/laminas-code": "^3.4 | ^4.0",
 		"insolita/yii2-fractal": "^1.0.0",
 		"fakerphp/faker": "^1.9",
 		"sam-it/yii2-mariadb": "^2.0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
             dockerfile: tests/docker/Dockerfile
             context: .
             args:
-              - PHP_VERSION=${PHP_VERSION:-7.4}
+              - BUILD_PHP_VERSION=${PHP_VERSION:-7.4}
         extra_hosts: # https://stackoverflow.com/a/67158212/1106908
             - "host.docker.internal:host-gateway"
         volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,14 @@
 version: "3.5"
 services:
     php:
+        image: yii2-openapi-php:${PHP_VERSION:-7.4}
         build:
             dockerfile: tests/docker/Dockerfile
             context: .
+            args:
+              - PHP_VERSION=${PHP_VERSION:-7.4}
+        extra_hosts: # https://stackoverflow.com/a/67158212/1106908
+            - "host.docker.internal:host-gateway"
         volumes:
             - ./tests/tmp/.composer:/root/.composer:rw
             - .:/app

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,15 +5,18 @@
 		convertNoticesToExceptions="true"
 		convertWarningsToExceptions="true"
 		stopOnFailure="false">
-		<testsuites>
-			<testsuite name="Test Suite">
-				<directory suffix="Test.php">./tests/unit</directory>
-			</testsuite>
-		</testsuites>
-		<filter>
-			<blacklist>
+	<testsuites>
+		<testsuite name="Test Suite">
+			<directory suffix="Test.php">./tests/unit</directory>
+		</testsuite>
+	</testsuites>
+	<filter>
+		<whitelist processUncoveredFilesFromWhitelist="true">
+			<directory suffix=".php">./src</directory>
+			<exclude>
 				<directory>./vendor</directory>
 				<directory>./tests</directory>
-			</blacklist>
-		</filter>
+			</exclude>
+		</whitelist>
+	</filter>
 </phpunit>

--- a/src/lib/ColumnToCode.php
+++ b/src/lib/ColumnToCode.php
@@ -156,14 +156,14 @@ class ColumnToCode
             return '$this->' . $this->fluentParts['type'];
         }
         if ($this->isBuiltinType) {
-            $parts = [
+            $parts = array_filter([
                 $this->fluentParts['type'],
                 $this->fluentParts['nullable'],
                 $this->fluentParts['default'],
                 $this->fluentParts['position']
-            ];
+            ]);
             array_unshift($parts, '$this');
-            return implode('->', array_filter(array_map('trim', $parts), 'trim'));
+            return implode('->', array_filter(array_map('trim', $parts)));
         }
         if ($this->rawParts['default'] === null) {
             $default = '';
@@ -508,7 +508,7 @@ class ColumnToCode
             if ($this->position === BaseMigrationBuilder::POS_FIRST) {
                 $this->fluentParts['position'] = 'first()';
                 $this->rawParts['position'] = BaseMigrationBuilder::POS_FIRST;
-            } elseif (strpos($this->position, BaseMigrationBuilder::POS_AFTER.' ') !== false) {
+            } elseif ($this->position !== null && strpos($this->position, BaseMigrationBuilder::POS_AFTER.' ') !== false) {
                 $previousColumn = str_replace(BaseMigrationBuilder::POS_AFTER.' ', '', $this->position);
                 $this->fluentParts['position'] = 'after(\''.$previousColumn.'\')';
                 $this->rawParts['position'] = BaseMigrationBuilder::POS_AFTER.' '.$previousColumn;

--- a/tests/DbTestCase.php
+++ b/tests/DbTestCase.php
@@ -35,7 +35,7 @@ class DbTestCase extends \PHPUnit\Framework\TestCase
         Yii::$container = new Container();
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (getenv('IN_DOCKER') !== 'docker') {
             $this->markTestSkipped('For docker env only');
@@ -45,7 +45,7 @@ class DbTestCase extends \PHPUnit\Framework\TestCase
         parent::setUp();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
         if (getenv('IN_DOCKER') === 'docker') {

--- a/tests/DbTestCase.php
+++ b/tests/DbTestCase.php
@@ -90,6 +90,22 @@ class DbTestCase extends \PHPUnit\Framework\TestCase
         self::assertInstanceOf(PgSqlSchema::class, Yii::$app->db->schema);
     }
 
+    /**
+     * Compare actual files to a base of expected files
+     * @param array $actual array of files to compare to expected files.
+     * @param string $testFile config file, which defines the directory, e.g. /tests/blog.php -> /tests/blog
+     * @return void
+     */
+    protected function compareFiles(array $actual, string $testFile)
+    {
+        foreach ($actual as $file) {
+            $expectedFile = str_replace('@app', substr($testFile, 0, -4), $file);
+            $actualFile = str_replace('@app', Yii::getAlias('@app'), $file);
+            // exec('cp '.$actualFile.' '.$expectedFile);
+            $this->checkFiles([$actualFile], [$expectedFile]);
+        }
+    }
+
     protected function checkFiles(array $actual, array $expected)
     {
         self::assertEquals(
@@ -100,6 +116,16 @@ class DbTestCase extends \PHPUnit\Framework\TestCase
             $expectedFilePath = $expected[$index];
             self::assertFileExists($file);
             self::assertFileExists($expectedFilePath);
+            $packages = require(__DIR__ . '/../vendor/composer/installed.php');
+            if (str_starts_with($packages['versions']['laminas/laminas-code']['version'], '4')) {
+                // Laminas Code adds 2 newlines between { } in version 3, but does not in version 4
+                file_put_contents($file,
+                    preg_replace('~(class .*)\n{\n}~i', "$1\n{\n\n\n}",
+                    preg_replace('~(class .*?)\n{\n*( *public function.*)}\n}\n\n$~is', "$1\n{\n\n$2}\n\n\n}\n\n",
+                        file_get_contents($file)
+                    ))
+                );
+            }
 
             $this->assertFileEquals($expectedFilePath, $file, "Failed asserting that file contents of\n$file\nare equal to file contents of\n$expectedFilePath \n\n cp $file $expectedFilePath \n\n ");
         }
@@ -138,7 +164,7 @@ class DbTestCase extends \PHPUnit\Framework\TestCase
     protected function runUpMigrations(string $db = 'mysql', int $number = 2): void
     {
         // up
-        exec('cd tests; ./yii migrate-'.$db.' --interactive=0', $upOutput, $upExitCode);
+        exec('cd tests; php -dxdebug.mode=develop ./yii migrate-'.$db.' --interactive=0', $upOutput, $upExitCode);
         $last = count($upOutput) - 1;
         $lastThird = count($upOutput) - 3;
         $this->assertSame($upExitCode, 0);
@@ -151,7 +177,7 @@ class DbTestCase extends \PHPUnit\Framework\TestCase
     protected function runDownMigrations(string $db = 'mysql', int $number = 2): void
     {
         // down
-        exec('cd tests; ./yii migrate-'.$db.'/down --interactive=0 '.$number, $downOutput, $downExitCode);
+        exec('cd tests; php -dxdebug.mode=develop ./yii migrate-'.$db.'/down --interactive=0 '.$number, $downOutput, $downExitCode);
         $last = count($downOutput) - 1;
         $lastThird = count($downOutput) - 3;
         $this->assertSame($downExitCode, 0);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,16 +13,6 @@ use function array_diff;
 
 class TestCase extends \PHPUnit\Framework\TestCase
 {
-    public static function assertEqualsCanonicalizing($expected, $actual, string $message = '')
-    {
-        if ((int)Version::id()[0] >= 8) {
-            parent::assertEqualsCanonicalizing($expected, $actual, $message);
-        } else {
-            self::assertTrue(empty(array_diff($expected, $actual)) && empty(array_diff($actual, $expected)));
-        }
-
-    }
-
     protected function prepareTempDir()
     {
         FileHelper::removeDirectory(__DIR__ . '/tmp/app');

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update && \
         apt-get clean && \
         rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
         # https://xdebug.org/docs/compat \
-        && if [ "$PHP_VERSION" = "8.2" ] ; then pecl install xdebug else pecl install xdebug-3.1.5 fi \
+        && if [ "$PHP_VERSION" = "8.2" ] ; then pecl install xdebug ; else pecl install xdebug-3.1.5 ; fi \
         && docker-php-ext-enable xdebug \
         && docker-php-ext-install \
                 zip \

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -1,4 +1,6 @@
-FROM php:7.1-cli
+ARG PHP_VERSION
+#FROM php:7.1-cli
+FROM php:$PHP_VERSION-cli
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -19,6 +21,7 @@ RUN apt-get update && \
             libicu-dev \
             libzip-dev \
             libpq-dev \
+            libonig-dev \
             nano \
             git \
             unzip\
@@ -29,7 +32,7 @@ RUN apt-get update && \
         --no-install-recommends && \
         apt-get clean && \
         rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-        && pecl install xdebug-2.9.6 \
+        && pecl install xdebug \
         && docker-php-ext-enable xdebug \
         && docker-php-ext-install \
                 zip \
@@ -62,11 +65,10 @@ RUN curl -o /tmp/composer-setup.php https://getcomposer.org/installer \
 ENV XDEBUGINI_PATH=/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
 RUN echo "xdebug.idekey=PHP_STORM" >> $XDEBUGINI_PATH && \
-    echo "xdebug.default_enable=1" >> $XDEBUGINI_PATH && \
-    echo "xdebug.remote_enable=1" >> $XDEBUGINI_PATH && \
-    echo "xdebug.remote_connect_back=1" >> $XDEBUGINI_PATH && \
-    echo "xdebug.remote_log=1" >> $XDEBUGINI_PATH && \
-    echo "xdebug.remote_port=9000" >> $XDEBUGINI_PATH && \
-    echo "xdebug.remote_autostart=1" >> $XDEBUGINI_PATH
+    echo "xdebug.mode=debug" >> $XDEBUGINI_PATH && \
+    echo "xdebug.start_with_request=yes" >> $XDEBUGINI_PATH && \
+    echo "xdebug.discover_client_host=1" >> $XDEBUGINI_PATH && \
+    echo "xdebug.client_port=9003" >> $XDEBUGINI_PATH  && \
+    echo "xdebug.client_host=host.docker.internal" >> $XDEBUGINI_PATH
 
 WORKDIR /app

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -32,7 +32,8 @@ RUN apt-get update && \
         --no-install-recommends && \
         apt-get clean && \
         rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-        && pecl install xdebug \
+        # https://xdebug.org/docs/compat \
+        && if [ "$PHP_VERSION" = "8.2" ] ; then pecl install xdebug else pecl install xdebug-3.1.5 fi \
         && docker-php-ext-enable xdebug \
         && docker-php-ext-install \
                 zip \

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -1,6 +1,8 @@
-ARG PHP_VERSION
+ARG BUILD_PHP_VERSION
 #FROM php:7.1-cli
-FROM php:$PHP_VERSION-cli
+FROM php:$BUILD_PHP_VERSION-cli
+# ARG is lost after FROM, so we need to specify it again https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG BUILD_PHP_VERSION
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -33,7 +35,7 @@ RUN apt-get update && \
         apt-get clean && \
         rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
         # https://xdebug.org/docs/compat \
-        && if [ "$PHP_VERSION" = "8.2" ] ; then pecl install xdebug ; else pecl install xdebug-3.1.5 ; fi \
+        && if [ "$BUILD_PHP_VERSION" = "8.2" ] ; then pecl install xdebug ; else pecl install xdebug-3.1.5 ; fi \
         && docker-php-ext-enable xdebug \
         && docker-php-ext-install \
                 zip \

--- a/tests/unit/GeneratorTest.php
+++ b/tests/unit/GeneratorTest.php
@@ -94,14 +94,7 @@ class GeneratorTest extends DbTestCase
         sort($actualFiles);
         $this->assertEquals($expectedFiles, $actualFiles);
 
-        foreach ($expectedFiles as $file) {
-            $expectedFile = str_replace('@app', substr($testFile, 0, -4), $file);
-            $actualFile = str_replace('@app', Yii::getAlias('@app'), $file);
-            $this->assertFileExists($expectedFile);
-            $this->assertFileExists($actualFile);
-            // exec('cp '.$actualFile.' '.$expectedFile);
-            $this->assertFileEquals($expectedFile, $actualFile, "Failed asserting that file contents of\n$actualFile\nare equal to file contents of\n$expectedFile");
-        }
+        $this->compareFiles($actualFiles, $testFile);
 
         if ($testFile === '/app/tests/specs/postgres_custom.php' ||
             $testFile === '/app/tests/specs/menu.php'

--- a/tests/unit/MultiDbFreshMigrationTest.php
+++ b/tests/unit/MultiDbFreshMigrationTest.php
@@ -58,7 +58,7 @@ class MultiDbFreshMigrationTest extends DbTestCase
         $this->compareFiles($expectedFiles, $testFile);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (getenv('IN_DOCKER') !== 'docker') {
             $this->markTestSkipped('For docker env only');
@@ -68,7 +68,7 @@ class MultiDbFreshMigrationTest extends DbTestCase
         parent::setUp();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
         if (getenv('IN_DOCKER') === 'docker') {

--- a/tests/unit/MultiDbFreshMigrationTest.php
+++ b/tests/unit/MultiDbFreshMigrationTest.php
@@ -89,17 +89,6 @@ class MultiDbFreshMigrationTest extends DbTestCase
         }
     }
 
-    protected function compareFiles(array $expected, string $testFile)
-    {
-        foreach ($expected as $file) {
-            $expectedFile = str_replace('@app', substr($testFile, 0, -4), $file);
-            $actualFile = str_replace('@app', Yii::getAlias('@app'), $file);
-            self::assertFileExists($expectedFile);
-            self::assertFileExists($actualFile);
-            $this->assertFileEquals($expectedFile, $actualFile, "Failed asserting that file contents of\n$actualFile\nare equal to file contents of\n$expectedFile\n\n cp $actualFile $expectedFile \n\n ");
-        }
-    }
-
     protected function findActualFiles():array
     {
         $actualFiles =  array_map(function($file) {
@@ -195,8 +184,8 @@ class MultiDbFreshMigrationTest extends DbTestCase
             $dbSchema, 'tableName', $columnSchema, false, false
         );
 
-        $this->assertContains('AFTER username', $column->getCode());
-        $this->assertNotContains('AFTER username', $columnWithoutPreviousCol->getCode());
+        $this->assertStringContainsString('AFTER username', $column->getCode());
+        $this->assertStringNotContainsString('AFTER username', $columnWithoutPreviousCol->getCode());
 
         // test `after` for fluent part in function call `after()`
         unset($column, $columnWithoutPreviousCol);
@@ -208,7 +197,7 @@ class MultiDbFreshMigrationTest extends DbTestCase
             $dbSchema, 'tableName', $columnSchema, true, false
         );
 
-        $this->assertContains("->after('username')", $column->getCode());
-        $this->assertNotContains("->after('username')", $columnWithoutPreviousCol->getCode());
+        $this->assertStringContainsString("->after('username')", $column->getCode());
+        $this->assertStringNotContainsString("->after('username')", $columnWithoutPreviousCol->getCode());
     }
 }

--- a/tests/unit/MultiDbSecondaryMigrationTest.php
+++ b/tests/unit/MultiDbSecondaryMigrationTest.php
@@ -67,7 +67,7 @@ class MultiDbSecondaryMigrationTest extends DbTestCase
         $this->compareFiles($expectedFiles, $testFile);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (getenv('IN_DOCKER') !== 'docker') {
             $this->markTestSkipped('For docker env only');
@@ -77,7 +77,7 @@ class MultiDbSecondaryMigrationTest extends DbTestCase
         parent::setUp();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
         if (getenv('IN_DOCKER') === 'docker') {

--- a/tests/unit/MultiDbSecondaryMigrationTest.php
+++ b/tests/unit/MultiDbSecondaryMigrationTest.php
@@ -99,17 +99,6 @@ class MultiDbSecondaryMigrationTest extends DbTestCase
         }
     }
 
-    protected function compareFiles(array $expected, string $testFile)
-    {
-        foreach ($expected as $file) {
-            $expectedFile = str_replace('@app', substr($testFile, 0, -4), $file);
-            $actualFile = str_replace('@app', Yii::getAlias('@app'), $file);
-            self::assertFileExists($expectedFile);
-            self::assertFileExists($actualFile);
-            $this->assertFileEquals($expectedFile, $actualFile, "Failed asserting that file contents of\n$actualFile\nare equal to file contents of\n$expectedFile");
-        }
-    }
-
     protected function findActualFiles():array
     {
         $actualFiles =  array_map(function($file) {

--- a/tests/unit/RelationsInFakerTest.php
+++ b/tests/unit/RelationsInFakerTest.php
@@ -111,8 +111,9 @@ class RelationsInFakerTest extends DbTestCase
                 }
             }
         }
-
-        $finalSortedModels = array_merge(array_keys($standalone), $sortedDependentModels);
+        $standalone = array_keys($standalone);
+        sort($standalone);
+        $finalSortedModels = array_merge($standalone, $sortedDependentModels);
         return $finalSortedModels;
     }
 

--- a/tests/unit/RelationsInFakerTest.php
+++ b/tests/unit/RelationsInFakerTest.php
@@ -32,14 +32,25 @@ class RelationsInFakerTest extends DbTestCase
         $finalSortedModels = static::sortModels($fakers);
 
         $this->assertSame($finalSortedModels, [
+            // 'Account',
+            // 'C123',
+            // 'D123',
+            // 'B123',
+            // 'E123',
+            // 'Domain',
+            // 'A123',
+            // 'Routing',
+
+            // 2nd order - sort() case
             'Account',
             'C123',
             'D123',
             'B123',
-            'E123',
-            'Domain',
             'A123',
+            'Domain',
+            'E123',
             'Routing',
+
         ]);
 
         $actualFiles = FileHelper::findFiles(Yii::getAlias('@app'), [
@@ -74,6 +85,7 @@ class RelationsInFakerTest extends DbTestCase
             }
         }
 
+        // this models are not dependent on any models
         $standalone = array_filter($modelsDependencies, function ($elm) {
             return $elm === null;
         });
@@ -84,6 +96,7 @@ class RelationsInFakerTest extends DbTestCase
 
         $justDepenentModels = array_keys($dependent);
         $sortedDependentModels = $justDepenentModels;
+        sort($sortedDependentModels);
 
         foreach ($justDepenentModels as $model) {
             if ($modelsDependencies[$model] !== null) {


### PR DESCRIPTION
Currently the php_version variable does not have any effect on the PHP version inside the docker container. This PR changes that.

- Drop Support for PHP 7.1
- Upgrade to Xdebug 3
- Upgrade PHPUnit to 8.x